### PR TITLE
Step8_동시성 테스트_통합 테스트

### DIFF
--- a/src/main/java/com/hhplus/commerce/application/item/ItemStockDecreaseService.java
+++ b/src/main/java/com/hhplus/commerce/application/item/ItemStockDecreaseService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class ItemStockService {
+public class ItemStockDecreaseService {
     private final ItemReader itemReader;
 
     @Transactional

--- a/src/main/java/com/hhplus/commerce/application/order/OrderCreateService.java
+++ b/src/main/java/com/hhplus/commerce/application/order/OrderCreateService.java
@@ -14,7 +14,7 @@ public class OrderCreateService {
     private final OrderStore orderStore;
 
     @Transactional
-    public Long createOrder(OrderRequest request) {
+    public Order createOrder(OrderRequest request) {
         Order savedOrder = orderStore.save(request.toEntity());
 
         //order aggregate
@@ -25,6 +25,6 @@ public class OrderCreateService {
             orderStore.saveOrderItemOption(orderItemOptionRequest.toEntity(savedOrderItem));
         });
 
-        return savedOrder.getId();
+        return savedOrder;
     }
 }

--- a/src/main/java/com/hhplus/commerce/application/order/OrderFacade.java
+++ b/src/main/java/com/hhplus/commerce/application/order/OrderFacade.java
@@ -1,0 +1,44 @@
+package com.hhplus.commerce.application.order;
+
+import com.hhplus.commerce.application.item.ItemStockDecreaseService;
+import com.hhplus.commerce.application.order.dto.PaymentRequest;
+import com.hhplus.commerce.application.point.PointUseService;
+import com.hhplus.commerce.application.point.dto.PointRequest;
+import com.hhplus.commerce.domain.order.Order;
+import com.hhplus.commerce.domain.order.dto.OrderRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderFacade {
+    private final ItemStockDecreaseService itemStockDecreaseService;
+    private final OrderCreateService orderCreateService;
+    private final PointUseService pointUseService;
+    private final PaymentCreateService paymentCreateService;
+
+    @Transactional
+    public Order order(OrderRequest request) {
+        // 재고차감
+        request.getOrderItemRequestList().forEach(orderItemRequest -> {
+            OrderRequest.OrderItemOptionRequest orderItemOptionRequest = orderItemRequest.getOrderItemOptionRequest();
+            itemStockDecreaseService.decreaseStock(orderItemOptionRequest.getItemOptionId(), Long.valueOf(orderItemRequest.getOrderCount()));
+        });
+
+        //주문 저장
+        return orderCreateService.createOrder(request);
+    }
+
+    @Transactional
+    public Long pay(Order order, PaymentRequest paymentRequest) {
+        //포인트차감
+        PointRequest pointRequest = PointRequest.builder().amount(paymentRequest.getAmount()).build();
+        Long leftPoint = pointUseService.usePoint(paymentRequest.getCustomerId(), pointRequest);
+
+        //결제
+        paymentCreateService.createPayment(order, paymentRequest);
+
+        return leftPoint;
+    }
+}

--- a/src/main/java/com/hhplus/commerce/application/order/PaymentCreateService.java
+++ b/src/main/java/com/hhplus/commerce/application/order/PaymentCreateService.java
@@ -32,5 +32,9 @@ public class PaymentCreateService {
         if (!order.getCustomerId().equals(paymentRequest.getCustomerId())) {
             throw new InvalidParamException(ErrorCode.PAYMENT_INVALID_CUSTOMER);
         }
+
+        if (!order.paymentAvailable()) {
+            throw new InvalidParamException(ErrorCode.PAYMENT_INVALID_ORDER);
+        }
     }
 }

--- a/src/main/java/com/hhplus/commerce/application/point/PointChargeService.java
+++ b/src/main/java/com/hhplus/commerce/application/point/PointChargeService.java
@@ -1,6 +1,6 @@
 package com.hhplus.commerce.application.point;
 
-import com.hhplus.commerce.application.point.dto.PointChargeRequest;
+import com.hhplus.commerce.application.point.dto.PointRequest;
 import com.hhplus.commerce.domain.point.Point;
 import com.hhplus.commerce.domain.point.PointReader;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +13,8 @@ public class PointChargeService {
     private final PointReader pointReader;
 
     @Transactional
-    public Long chargePoint(Long customerId, PointChargeRequest pointChargeRequest) {
+    public Long chargePoint(Long customerId, PointRequest pointRequest) {
         Point point = pointReader.getPointWithPessimisticLock(customerId);
-        return point.charge(pointChargeRequest.getAmount());
+        return point.charge(pointRequest.getAmount());
     }
 }

--- a/src/main/java/com/hhplus/commerce/application/point/PointUseService.java
+++ b/src/main/java/com/hhplus/commerce/application/point/PointUseService.java
@@ -1,6 +1,6 @@
 package com.hhplus.commerce.application.point;
 
-import com.hhplus.commerce.application.point.dto.PointChargeRequest;
+import com.hhplus.commerce.application.point.dto.PointRequest;
 import com.hhplus.commerce.domain.point.Point;
 import com.hhplus.commerce.domain.point.PointReader;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +13,8 @@ public class PointUseService {
     private final PointReader pointReader;
 
     @Transactional
-    public Long usePoint(Long customerId, PointChargeRequest pointChargeRequest) {
+    public Long usePoint(Long customerId, PointRequest pointRequest) {
         Point point = pointReader.getPointWithPessimisticLock(customerId);
-        return point.use(pointChargeRequest.getAmount());
+        return point.use(pointRequest.getAmount());
     }
 }

--- a/src/main/java/com/hhplus/commerce/application/point/dto/PointRequest.java
+++ b/src/main/java/com/hhplus/commerce/application/point/dto/PointRequest.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 @Getter
 @AllArgsConstructor
 @Schema(description = "잔액 충전 요청")
-public class PointChargeRequest {
+public class PointRequest {
     @Schema(description = "충전 할 포인트", example = "1000")
     private Long amount;
 }

--- a/src/main/java/com/hhplus/commerce/common/response/ErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/common/response/ErrorCode.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+    //common
+    COMMON_ILLEGAL_STATUS(HttpStatus.BAD_REQUEST.value(), "잘못된 상태값입니다."),
+
     //item
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 상품입니다."),
     ITEM_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 상품 옵션입니다."),
@@ -27,6 +30,7 @@ public enum ErrorCode {
     //payment
     PAYMENT_INVALID_PRICE(HttpStatus.BAD_REQUEST.value(), "요청 금액이 잘못되었습니다."),
     PAYMENT_INVALID_CUSTOMER(HttpStatus.BAD_REQUEST.value(), "주문자와 결제자가 다릅니다."),
+    PAYMENT_INVALID_ORDER(HttpStatus.CONFLICT.value(), "이미 결제가 완료되었습니다."),
 
     //cart
     CART_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 장바구니 입니다."),

--- a/src/main/java/com/hhplus/commerce/common/response/ErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/common/response/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     PAYMENT_INVALID_PRICE(HttpStatus.BAD_REQUEST.value(), "요청 금액이 잘못되었습니다."),
     PAYMENT_INVALID_CUSTOMER(HttpStatus.BAD_REQUEST.value(), "주문자와 결제자가 다릅니다."),
     PAYMENT_INVALID_ORDER(HttpStatus.CONFLICT.value(), "이미 결제가 완료되었습니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.CONFLICT.value(), "존재하지 않는 결제입니다."),
 
     //cart
     CART_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 장바구니 입니다."),

--- a/src/main/java/com/hhplus/commerce/domain/Item/Item.java
+++ b/src/main/java/com/hhplus/commerce/domain/Item/Item.java
@@ -39,6 +39,7 @@ public class Item extends BaseTimeEntity {
 
     public Item addItemOption(ItemOption itemOption) {
         itemOptions.add(itemOption);
+        itemOption.changeItem(this);
         return this;
     }
 }

--- a/src/main/java/com/hhplus/commerce/domain/Item/ItemStore.java
+++ b/src/main/java/com/hhplus/commerce/domain/Item/ItemStore.java
@@ -7,5 +7,6 @@ public interface ItemStore {
     Item saveItem(Item item);
 
     ItemOption saveItemOption(ItemOption itemOption);
+
     ItemInventory saveItemInventory(ItemInventory itemInventory);
 }

--- a/src/main/java/com/hhplus/commerce/domain/Item/ItemStore.java
+++ b/src/main/java/com/hhplus/commerce/domain/Item/ItemStore.java
@@ -1,0 +1,11 @@
+package com.hhplus.commerce.domain.Item;
+
+import com.hhplus.commerce.domain.Item.itemInventory.ItemInventory;
+import com.hhplus.commerce.domain.Item.itemOption.ItemOption;
+
+public interface ItemStore {
+    Item saveItem(Item item);
+
+    ItemOption saveItemOption(ItemOption itemOption);
+    ItemInventory saveItemInventory(ItemInventory itemInventory);
+}

--- a/src/main/java/com/hhplus/commerce/domain/Item/itemInventory/ItemInventory.java
+++ b/src/main/java/com/hhplus/commerce/domain/Item/itemInventory/ItemInventory.java
@@ -34,6 +34,11 @@ public class ItemInventory {
         this.quantity = quantity;
     }
 
+
+    public void changeItemOption(ItemOption itemOption) {
+        this.itemOption = itemOption;
+    }
+
     public Long decreaseStock(Long quantity) {
         this.quantity -= quantity;
         if (this.quantity < 0) {
@@ -42,4 +47,5 @@ public class ItemInventory {
 
         return this.quantity;
     }
+
 }

--- a/src/main/java/com/hhplus/commerce/domain/Item/itemOption/ItemOption.java
+++ b/src/main/java/com/hhplus/commerce/domain/Item/itemOption/ItemOption.java
@@ -20,7 +20,7 @@ public class ItemOption {
     @ToString.Exclude
     private Item item;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "itemOption", cascade = CascadeType.PERSIST)
     @ToString.Exclude
     private ItemInventory itemInventory;
 
@@ -45,8 +45,13 @@ public class ItemOption {
         this.itemOptionPrice = itemOptionPrice;
     }
 
+    public void changeItem(Item item) {
+        this.item = item;
+    }
+
     public ItemOption changeInventory(ItemInventory itemInventory) {
         this.itemInventory = itemInventory;
+        itemInventory.changeItemOption(this);
         return this;
     }
 

--- a/src/main/java/com/hhplus/commerce/domain/customer/Customer.java
+++ b/src/main/java/com/hhplus/commerce/domain/customer/Customer.java
@@ -2,15 +2,13 @@ package com.hhplus.commerce.domain.customer;
 
 import com.hhplus.commerce.common.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "customers")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@ToString
 public class Customer extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/hhplus/commerce/domain/customer/CustomerStore.java
+++ b/src/main/java/com/hhplus/commerce/domain/customer/CustomerStore.java
@@ -1,0 +1,5 @@
+package com.hhplus.commerce.domain.customer;
+
+public interface CustomerStore {
+    Customer save(Customer customer);
+}

--- a/src/main/java/com/hhplus/commerce/domain/order/Order.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/Order.java
@@ -1,6 +1,8 @@
 package com.hhplus.commerce.domain.order;
 
 import com.hhplus.commerce.common.BaseTimeEntity;
+import com.hhplus.commerce.common.exception.IllegalStatusException;
+import com.hhplus.commerce.common.response.ErrorCode;
 import com.hhplus.commerce.domain.order.address.Address;
 import com.hhplus.commerce.domain.order.item.OrderItem;
 import jakarta.persistence.*;
@@ -52,5 +54,17 @@ public class Order extends BaseTimeEntity {
         return orderItems.stream()
                 .mapToLong(OrderItem::calculatePrice)
                 .sum();
+    }
+
+    public void orderComplete() {
+        if (status != OrderStatus.INIT) {
+            throw new IllegalStatusException(ErrorCode.COMMON_ILLEGAL_STATUS);
+        }
+
+        this.status = OrderStatus.ORDER_COMPLETE;
+    }
+
+    public boolean paymentAvailable() {
+        return status == OrderStatus.INIT;
     }
 }

--- a/src/main/java/com/hhplus/commerce/domain/order/OrderReader.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/OrderReader.java
@@ -1,6 +1,7 @@
 package com.hhplus.commerce.domain.order;
 
 import com.hhplus.commerce.application.item.dto.ItemBestResponse;
+import com.hhplus.commerce.domain.order.payment.Payment;
 
 import java.util.List;
 
@@ -8,4 +9,6 @@ public interface OrderReader {
     Order getOrder(Long id);
 
     List<ItemBestResponse> getBestItems();
+
+    Payment getPayment(Long orderId);
 }

--- a/src/main/java/com/hhplus/commerce/domain/order/dto/OrderRequest.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/dto/OrderRequest.java
@@ -5,10 +5,7 @@ import com.hhplus.commerce.domain.order.address.Address;
 import com.hhplus.commerce.domain.order.item.OrderItem;
 import com.hhplus.commerce.domain.order.item.OrderItemOption;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -16,6 +13,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 @Schema(description = "주문 요청")
 public class OrderRequest {
     @Schema(description = "고객 식별자", example = "1")
@@ -50,6 +48,7 @@ public class OrderRequest {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @ToString
     @Schema(description = "주문 상품 요청")
     public static class OrderItemRequest {
         @Schema(description = "상품 재고", example = "10")
@@ -85,8 +84,12 @@ public class OrderRequest {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @ToString
     @Schema(description = "주문 상품 옵션 요청")
     public static class OrderItemOptionRequest {
+        @Schema(description = "상품 옵션 식별자", example = "3")
+        private Long itemOptionId;
+
         @Schema(description = "상품 옵션 사이즈", example = "95")
         private String itemOptionSize;
 

--- a/src/main/java/com/hhplus/commerce/domain/point/Point.java
+++ b/src/main/java/com/hhplus/commerce/domain/point/Point.java
@@ -4,15 +4,13 @@ import com.hhplus.commerce.common.BaseTimeEntity;
 import com.hhplus.commerce.common.exception.IllegalStatusException;
 import com.hhplus.commerce.common.response.ErrorCode;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "points")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@ToString
 public class Point extends BaseTimeEntity {
     public static final long MAX_POINT = 100000L;
     public static final long MIN_POINT = 0L;

--- a/src/main/java/com/hhplus/commerce/domain/point/PointStore.java
+++ b/src/main/java/com/hhplus/commerce/domain/point/PointStore.java
@@ -1,0 +1,5 @@
+package com.hhplus.commerce.domain.point;
+
+public interface PointStore {
+    Point save(Point point);
+}

--- a/src/main/java/com/hhplus/commerce/infra/customer/CustomerStoreImpl.java
+++ b/src/main/java/com/hhplus/commerce/infra/customer/CustomerStoreImpl.java
@@ -1,0 +1,16 @@
+package com.hhplus.commerce.infra.customer;
+
+import com.hhplus.commerce.domain.customer.Customer;
+import com.hhplus.commerce.domain.customer.CustomerStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomerStoreImpl implements CustomerStore {
+    private final CustomerRepository customerRepository;
+
+    public Customer save(Customer customer) {
+        return customerRepository.save(customer);
+    }
+}

--- a/src/main/java/com/hhplus/commerce/infra/item/ItemStoreImpl.java
+++ b/src/main/java/com/hhplus/commerce/infra/item/ItemStoreImpl.java
@@ -1,0 +1,31 @@
+package com.hhplus.commerce.infra.item;
+
+import com.hhplus.commerce.domain.Item.Item;
+import com.hhplus.commerce.domain.Item.ItemStore;
+import com.hhplus.commerce.domain.Item.itemInventory.ItemInventory;
+import com.hhplus.commerce.domain.Item.itemOption.ItemOption;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ItemStoreImpl implements ItemStore {
+    private final ItemRepository itemRepository;
+    private final ItemOptionRepository itemOptionRepository;
+    private final ItemInventoryRepository itemInventoryRepository;
+
+    @Override
+    public Item saveItem(Item item) {
+        return itemRepository.save(item);
+    }
+
+    @Override
+    public ItemOption saveItemOption(ItemOption itemOption) {
+        return itemOptionRepository.save(itemOption);
+    }
+
+    @Override
+    public ItemInventory saveItemInventory(ItemInventory itemInventory) {
+        return itemInventoryRepository.save(itemInventory);
+    }
+}

--- a/src/main/java/com/hhplus/commerce/infra/order/OrderReaderImpl.java
+++ b/src/main/java/com/hhplus/commerce/infra/order/OrderReaderImpl.java
@@ -5,6 +5,8 @@ import com.hhplus.commerce.common.exception.EntityNotFoundException;
 import com.hhplus.commerce.common.response.ErrorCode;
 import com.hhplus.commerce.domain.order.Order;
 import com.hhplus.commerce.domain.order.OrderReader;
+import com.hhplus.commerce.domain.order.payment.Payment;
+import com.hhplus.commerce.infra.order.payment.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +18,7 @@ import java.util.List;
 public class OrderReaderImpl implements OrderReader {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
+    private final PaymentRepository paymentRepository;
 
     @Override
     public Order getOrder(Long orderId) {
@@ -28,5 +31,11 @@ public class OrderReaderImpl implements OrderReader {
         LocalDateTime endDate = LocalDateTime.now();
         LocalDateTime startDate = endDate.minusDays(3);
         return orderItemRepository.findTop5ByOrderCountSum(startDate, endDate);
+    }
+
+    @Override
+    public Payment getPayment(Long orderId) {
+        return paymentRepository.findById(orderId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PAYMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/hhplus/commerce/infra/point/PointStoreImpl.java
+++ b/src/main/java/com/hhplus/commerce/infra/point/PointStoreImpl.java
@@ -1,0 +1,17 @@
+package com.hhplus.commerce.infra.point;
+
+import com.hhplus.commerce.domain.point.Point;
+import com.hhplus.commerce.domain.point.PointStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PointStoreImpl implements PointStore {
+    private final PointRepository pointRepository;
+
+    @Override
+    public Point save(Point point) {
+        return pointRepository.save(point);
+    }
+}

--- a/src/main/java/com/hhplus/commerce/interfaces/point/PointApiController.java
+++ b/src/main/java/com/hhplus/commerce/interfaces/point/PointApiController.java
@@ -2,7 +2,7 @@ package com.hhplus.commerce.interfaces.point;
 
 import com.hhplus.commerce.application.point.PointChargeService;
 import com.hhplus.commerce.application.point.PointQueryService;
-import com.hhplus.commerce.application.point.dto.PointChargeRequest;
+import com.hhplus.commerce.application.point.dto.PointRequest;
 import com.hhplus.commerce.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +27,7 @@ public class PointApiController implements PointApiSpecification {
     @PostMapping("/charge")
     public CommonResponse chargePoint(
             @RequestHeader("customerId") Long customerId,
-            @RequestBody PointChargeRequest request
+            @RequestBody PointRequest request
     ) {
 //        Long charegdPoint = pointChargeService.chargePoint(customerId, request);
 //

--- a/src/main/java/com/hhplus/commerce/interfaces/point/PointApiSpecification.java
+++ b/src/main/java/com/hhplus/commerce/interfaces/point/PointApiSpecification.java
@@ -2,7 +2,7 @@ package com.hhplus.commerce.interfaces.point;
 
 import com.hhplus.commerce.application.point.dto.PointResponse;
 import com.hhplus.commerce.common.response.CommonResponse;
-import com.hhplus.commerce.application.point.dto.PointChargeRequest;
+import com.hhplus.commerce.application.point.dto.PointRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,7 +17,7 @@ public interface PointApiSpecification {
     @Operation(summary = "포인트 충전", description = "💡주어진 식별자와 금액으로 해당 고객의 포인트를 충전하고 반환합니다")
     CommonResponse chargePoint(
             @Parameter(description = "고객 식별자") Long customerId,
-            @Parameter(description = "포인트 충전 정보") PointChargeRequest request
+            @Parameter(description = "포인트 충전 정보") PointRequest request
     );
 
     final class Fake implements PointApiSpecification {
@@ -32,7 +32,7 @@ public interface PointApiSpecification {
         }
 
         @Override
-        public CommonResponse chargePoint(Long customerId, PointChargeRequest request) {
+        public CommonResponse chargePoint(Long customerId, PointRequest request) {
             PointResponse pointResponse = PointResponse.builder()
                     .customerId(customerId)
                     .point(2000L)

--- a/src/test/java/com/hhplus/commerce/application/item/ItemStockDecreaseConcurrencyTest.java
+++ b/src/test/java/com/hhplus/commerce/application/item/ItemStockDecreaseConcurrencyTest.java
@@ -1,0 +1,95 @@
+package com.hhplus.commerce.application.item;
+
+import com.hhplus.commerce.domain.Item.Item;
+import com.hhplus.commerce.domain.Item.ItemReader;
+import com.hhplus.commerce.domain.Item.ItemStore;
+import com.hhplus.commerce.domain.Item.itemInventory.ItemInventory;
+import com.hhplus.commerce.domain.Item.itemOption.ItemOption;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class ItemStockDecreaseConcurrencyTest {
+    private final ItemStockDecreaseService itemStockDecreaseService;
+    private final ItemStore itemStore;
+    private final ItemReader itemReader;
+
+    public ItemStockDecreaseConcurrencyTest(
+            @Autowired ItemStore itemStore,
+            @Autowired ItemStockDecreaseService itemStockDecreaseService,
+            @Autowired ItemReader itemReader
+    ) {
+        this.itemStore = itemStore;
+        this.itemStockDecreaseService = itemStockDecreaseService;
+        this.itemReader = itemReader;
+    }
+
+    @BeforeEach
+    void setUp() {
+        Item item = createItem(null);
+        ItemOption itemOption = createItemOption(null, item);
+        ItemInventory itemInventory = createItemInventory(null, itemOption, 10L);
+        item.addItemOption(itemOption);
+        itemOption.changeInventory(itemInventory);
+
+        Item createdItem = itemStore.saveItem(item);
+        ItemOption createdItemOption = itemStore.saveItemOption(itemOption);
+        ItemInventory createdItemInventory = itemStore.saveItemInventory(itemInventory);
+    }
+
+    @Test
+    @DisplayName("10개의 상품을 동시에 1개씩 총 10번 차감하면 재고는 0개이다.")
+    void concurrentDecreaseForSamePoint10times() throws InterruptedException {
+        final int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger success = new AtomicInteger(0);
+
+        for (int i = 1; i <= threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    itemStockDecreaseService.decreaseStock(1L, 1L);
+                    success.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        assertThat(success.get()).isEqualTo(10);
+        assertThat(itemReader.getItemInventory(1L).getQuantity()).isEqualTo(0);
+    }
+
+    private Item createItem(Long id) {
+        return Item.builder()
+                .id(id)
+                .build();
+    }
+
+    private ItemOption createItemOption(Long id, Item item) {
+        return ItemOption.builder()
+                .id(id)
+                .item(item)
+                .build();
+    }
+
+    private ItemInventory createItemInventory(Long id, ItemOption itemOption, Long quantity) {
+        return ItemInventory.builder()
+                .id(id)
+                .itemOption(itemOption)
+                .quantity(quantity)
+                .build();
+    }
+}

--- a/src/test/java/com/hhplus/commerce/application/item/ItemStockDecreaseServiceTest.java
+++ b/src/test/java/com/hhplus/commerce/application/item/ItemStockDecreaseServiceTest.java
@@ -16,14 +16,14 @@ import static org.mockito.Mockito.*;
 
 @SuppressWarnings({"InnerClassMayBeStatic"})
 @DisplayName("ItemStockService 클래스")
-class ItemStockServiceTest {
+class ItemStockDecreaseServiceTest {
     private ItemReader itemReader;
-    private ItemStockService itemStockService;
+    private ItemStockDecreaseService itemStockDecreaseService;
 
     @BeforeEach
     void setUp() {
         itemReader = mock(ItemReader.class);
-        itemStockService = new ItemStockService(itemReader);
+        itemStockDecreaseService = new ItemStockDecreaseService(itemReader);
     }
 
     @Nested
@@ -42,7 +42,7 @@ class ItemStockServiceTest {
                 ItemInventory itemInventory = createItemInventory(existedItemInventoryId, 20L);
                 given(itemReader.getItemInventory(existedItemOptionId)).willReturn(itemInventory);
 
-                Long leftQuantity = itemStockService.decreaseStock(existedItemOptionId, quantity);
+                Long leftQuantity = itemStockDecreaseService.decreaseStock(existedItemOptionId, quantity);
 
                 assertThat(leftQuantity).isEqualTo(20L - quantity);
             }
@@ -59,7 +59,7 @@ class ItemStockServiceTest {
                 given(itemReader.getItemInventory(notExistedItemOptionId)).willThrow(EntityNotFoundException.class);
 
                 assertThatThrownBy(
-                        () -> itemStockService.decreaseStock(notExistedItemOptionId, 10L)
+                        () -> itemStockDecreaseService.decreaseStock(notExistedItemOptionId, 10L)
                 )
                         .isInstanceOf(EntityNotFoundException.class);
             }
@@ -79,7 +79,7 @@ class ItemStockServiceTest {
                 given(itemReader.getItemInventory(existedItemOptionId)).willReturn(itemInventory);
 
                 assertThatThrownBy(
-                        () -> itemStockService.decreaseStock(existedItemOptionId, quantity)
+                        () -> itemStockDecreaseService.decreaseStock(existedItemOptionId, quantity)
                 )
                         .isInstanceOf(IllegalStatusException.class);
             }

--- a/src/test/java/com/hhplus/commerce/application/order/OrderCreateServiceTest.java
+++ b/src/test/java/com/hhplus/commerce/application/order/OrderCreateServiceTest.java
@@ -40,16 +40,16 @@ class OrderCreateServiceTest {
             private final Long createdOrderItemOptionId = 3L;
 
             @Test
-            @DisplayName("주문을 생성하고 주문 식별자를 반환한다")
-            void it_returns_created_order_id() {
+            @DisplayName("주문을 생성하고 반환한다")
+            void it_returns_created_order() {
                 Order order = createOrderAggregate(createdOrderId, createdOrderItemId, createdOrderItemOptionId);
                 OrderRequest orderRequest = createOrderRequest();
 
                 given(orderStore.save(any(Order.class))).willReturn(order);
 
-                Long orderId = orderCreateService.createOrder(orderRequest);
+                Order createdOrder = orderCreateService.createOrder(orderRequest);
 
-                assertThat(orderId).isEqualTo(createdOrderId);
+                assertThat(createdOrder.getId()).isEqualTo(createdOrderId);
                 verify(orderStore, times(1)).save(any(Order.class));
                 verify(orderStore, times(1)).saveOrderItem(any(OrderItem.class));
                 verify(orderStore, times(1)).saveOrderItemOption(any(OrderItemOption.class));

--- a/src/test/java/com/hhplus/commerce/application/order/OrderFacadeOrderTest.java
+++ b/src/test/java/com/hhplus/commerce/application/order/OrderFacadeOrderTest.java
@@ -1,0 +1,144 @@
+package com.hhplus.commerce.application.order;
+
+import com.hhplus.commerce.common.exception.IllegalStatusException;
+import com.hhplus.commerce.domain.Item.Item;
+import com.hhplus.commerce.domain.Item.ItemReader;
+import com.hhplus.commerce.domain.Item.ItemStore;
+import com.hhplus.commerce.domain.Item.itemInventory.ItemInventory;
+import com.hhplus.commerce.domain.Item.itemOption.ItemOption;
+import com.hhplus.commerce.domain.order.Order;
+import com.hhplus.commerce.domain.order.OrderStore;
+import com.hhplus.commerce.domain.order.dto.OrderRequest;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class OrderFacadeOrderTest {
+    private final OrderFacade orderFacade;
+    private final ItemStore itemStore;
+    private final ItemReader itemReader;
+    private final OrderStore orderStore;
+
+    public OrderFacadeOrderTest(
+            @Autowired OrderFacade orderFacade,
+            @Autowired ItemStore itemStore,
+            @Autowired ItemReader itemReader,
+            @Autowired OrderStore orderStore
+    ) {
+        this.orderFacade = orderFacade;
+        this.itemStore = itemStore;
+        this.itemReader = itemReader;
+        this.orderStore = orderStore;
+    }
+
+    @Test
+    @org.junit.jupiter.api.Order(1)
+    @DisplayName("주어진 주문정보에 따라 재고를 차감하고 주문서를 생성한다")
+    void order() {
+        itemFixture();
+        OrderRequest orderRequest = createOrderRequest();
+
+        Order createdOrder = orderFacade.order(orderRequest);
+
+        ItemInventory itemInventory = itemReader.getItemInventory(1L);
+        Assertions.assertEquals(itemInventory.getQuantity(), 8, "10개 중 2개를 주문하면 재고는 8개가 남는다.");
+        Assertions.assertEquals(createdOrder.getId(), 1L, "새로운 주문서가 생성됩니다.");
+    }
+
+    @Test
+    @org.junit.jupiter.api.Order(2)
+    @DisplayName("잔고 8개에서 동시에 2개씩 10번 주문을 신청하면 4번은 성공하고 6번은 재고 없음으로 실패한다.")
+    void orderThrowsIllegaStatusException() throws InterruptedException {
+        final int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger success = new AtomicInteger(0);
+        AtomicInteger fail = new AtomicInteger(0);
+
+        for (int i = 1; i <= threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    OrderRequest orderRequest = createOrderRequest();
+                    Order createdOrder = orderFacade.order(orderRequest);
+                    success.incrementAndGet();
+                } catch (IllegalStatusException e) {
+                    fail.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Assertions.assertEquals(success.get(), 4, "재고가 8개이므로 2개씩 4번 주문 가능하다");
+        Assertions.assertEquals(fail.get(), 6, "재고가 8개이므로 초과 주문은 예외를 반환한다");
+    }
+
+    //item
+    private Item itemFixture() {
+        Item item = createItem(null);
+        ItemOption itemOption = createItemOption(null, item);
+        ItemInventory itemInventory = createItemInventory(null, itemOption, 10L);
+        item.addItemOption(itemOption);
+        itemOption.changeInventory(itemInventory);
+
+        Item createdItem = itemStore.saveItem(item);
+        ItemOption createdItemOption = itemStore.saveItemOption(itemOption);
+        ItemInventory createdItemInventory = itemStore.saveItemInventory(itemInventory);
+
+        return item;
+    }
+
+    private Item createItem(Long id) {
+        return Item.builder()
+                .id(id)
+                .build();
+    }
+
+    private ItemOption createItemOption(Long id, Item item) {
+        return ItemOption.builder()
+                .id(id)
+                .item(item)
+                .build();
+    }
+
+    private ItemInventory createItemInventory(Long id, ItemOption itemOption, Long quantity) {
+        return ItemInventory.builder()
+                .id(id)
+                .itemOption(itemOption)
+                .quantity(quantity)
+                .build();
+    }
+
+    private OrderRequest createOrderRequest() {
+        OrderRequest.OrderItemOptionRequest orderItemOptionRequest =
+                OrderRequest.OrderItemOptionRequest
+                        .builder()
+                        .itemOptionId(1L)
+                        .build();
+
+        List<OrderRequest.OrderItemRequest> orderItemRequestList =
+                List.of(
+                        OrderRequest.OrderItemRequest.builder()
+                            .orderItemOptionRequest(orderItemOptionRequest)
+                            .itemId(1L)
+                            .orderCount(2)
+                            .itemPrice(1000L)
+                            .build()
+                );
+
+        return OrderRequest.builder()
+                .orderItemRequestList(orderItemRequestList)
+                .customerId(1L)
+                .build();
+    }
+}

--- a/src/test/java/com/hhplus/commerce/application/order/OrderFacadePayTest.java
+++ b/src/test/java/com/hhplus/commerce/application/order/OrderFacadePayTest.java
@@ -1,0 +1,171 @@
+package com.hhplus.commerce.application.order;
+
+import com.hhplus.commerce.application.order.dto.PaymentRequest;
+import com.hhplus.commerce.common.exception.IllegalStatusException;
+import com.hhplus.commerce.common.exception.InvalidParamException;
+import com.hhplus.commerce.domain.customer.Customer;
+import com.hhplus.commerce.domain.customer.CustomerStore;
+import com.hhplus.commerce.domain.order.Order;
+import com.hhplus.commerce.domain.order.OrderReader;
+import com.hhplus.commerce.domain.order.OrderStore;
+import com.hhplus.commerce.domain.order.item.OrderItem;
+import com.hhplus.commerce.domain.order.item.OrderItemOption;
+import com.hhplus.commerce.domain.order.payment.Payment;
+import com.hhplus.commerce.domain.point.Point;
+import com.hhplus.commerce.domain.point.PointStore;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class OrderFacadePayTest {
+    private final OrderFacade orderFacade;
+    private final OrderStore orderStore;
+    private final OrderReader orderReader;
+    private final PointStore pointStore;
+    private final CustomerStore customerStore;
+
+    private Order order;
+
+    public OrderFacadePayTest(
+            @Autowired OrderFacade orderFacade,
+            @Autowired OrderStore orderStore,
+            @Autowired OrderReader orderReader,
+            @Autowired PointStore pointStore,
+            @Autowired CustomerStore customerStore
+    ) {
+        this.orderFacade = orderFacade;
+        this.orderStore = orderStore;
+        this.orderReader = orderReader;
+        this.pointStore = pointStore;
+        this.customerStore = customerStore;
+    }
+
+    @Test
+    @org.junit.jupiter.api.Order(1)
+    @DisplayName("주어진 결제정보에 따라 포인트를 차감하고 결제 정보를 생성한다.")
+    void order() {
+        Customer customer = customerFixture(null);
+        Point point = pointFixture(customer.getId());
+        order = orderFixture(customer.getId());
+        PaymentRequest paymentRequest = createPaymentRequest(1L, 1L, "TOSS", 10000L);
+
+        Long leftPoint = orderFacade.pay(order, paymentRequest);
+
+        Assertions.assertEquals(order.calculatePrice(), 10000L, "5000원 2개 주문하므로 주문 가격은 총 10000원이다.");
+        Assertions.assertEquals(customer.getId(), order.getCustomerId(), "주문자와 결제자는 똑같다.");
+        Assertions.assertEquals(leftPoint, 10000L, "20000 포인트에서 10000원을 결제해 10000 포인트가 남는다.");
+
+        Payment payment = orderReader.getPayment(order.getId());
+        Assertions.assertEquals(payment.getId(), 1L, "결제가 정상이면 새로운 결제 정보가 생성된다.");
+    }
+
+    @Test
+    @org.junit.jupiter.api.Order(2)
+    @DisplayName("결제 금액보다 포인트 잔액이 부족하면 예외를 반환한다")
+    void orderWithOverAmount() {
+        PaymentRequest paymentRequest = createPaymentRequest(1L, 1L, "TOSS", 20000L);
+
+        assertThatThrownBy(
+                () -> orderFacade.pay(order, paymentRequest)
+        )
+                .isInstanceOf(IllegalStatusException.class);
+    }
+
+    @Test
+    @org.junit.jupiter.api.Order(3)
+    @DisplayName("결제금액과 요청금액이 다르면 예외를 반환한다.")
+    void orderWithInvalidAmount() {
+        Customer customer = customerFixture(null);
+        Point point = pointFixture(customer.getId());
+        order = orderFixture(customer.getId());
+
+        PaymentRequest paymentRequest = createPaymentRequest(1L, 1L, "TOSS", 5000L);
+
+        assertThatThrownBy(
+                () -> orderFacade.pay(order, paymentRequest)
+        )
+                .isInstanceOf(InvalidParamException.class);
+    }
+
+    //point
+    private Point pointFixture(Long customerId) {
+        Point point = createPoint(customerId, 20000L);
+
+        return pointStore.save(point);
+    }
+
+    //point
+    private Point createPoint(Long customerId, Long point) {
+        return Point.builder()
+                .customerId(customerId)
+                .point(point)
+                .build();
+    }
+
+    //customer
+    private Customer customerFixture(Long id) {
+        Customer customer = createCustomer(id);
+
+        return customerStore.save(customer);
+    }
+
+    private Customer createCustomer(Long id) {
+        return Customer.builder()
+                .id(id)
+                .build();
+    }
+
+    //order
+    private Order orderFixture(Long customerId) {
+        Order order = createOrder(null, customerId);
+        OrderItem orderItem = createOrderItem(null, 2, order);
+        OrderItemOption orderItemOption = createOrderItemOption(null, orderItem);
+        orderItem.changeOrderItemOption(orderItemOption);
+        order.addOrderItem(orderItem);
+
+        orderStore.save(order);
+        orderStore.saveOrderItem(orderItem);
+        orderStore.saveOrderItemOption(orderItemOption);
+
+        return order;
+    }
+
+    private Order createOrder(Long id, Long customerId) {
+        return Order.builder()
+                .id(id)
+                .customerId(customerId)
+                .build();
+    }
+
+    private OrderItem createOrderItem(Long id, Integer orderCount, Order order) {
+        return OrderItem.builder()
+                .id(id)
+                .orderCount(orderCount)
+                .order(order)
+                .itemPrice(5000L)
+                .orderCount(2)
+                .build();
+    }
+
+    private OrderItemOption createOrderItemOption(Long id, OrderItem orderItem) {
+        return OrderItemOption.builder()
+                .id(id)
+                .oderItem(orderItem)
+                .itemOptionPrice(0L)
+                .build();
+    }
+
+    //payment
+    private PaymentRequest createPaymentRequest(Long orderId, Long customerId, String paymentMethod, Long amount) {
+        return PaymentRequest.builder()
+                .orderId(orderId)
+                .customerId(customerId)
+                .paymentMethod(paymentMethod)
+                .amount(amount)
+                .build();
+    }
+}

--- a/src/test/java/com/hhplus/commerce/application/point/PointChargeConcurrencyTest.java
+++ b/src/test/java/com/hhplus/commerce/application/point/PointChargeConcurrencyTest.java
@@ -75,7 +75,7 @@ public class PointChargeConcurrencyTest {
     }
 
     @Test
-    @DisplayName("1명이 50000원씩 10번을 동시에 충전하면 2번 성공하고 8번 실패한다.")
+    @DisplayName("1명이 40000원씩 10번을 동시에 충전하면 2번 성공하고 8번 실패한다.")
     void concurrentCharegForSamePoint10timesOverMax() throws InterruptedException {
         final int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
@@ -86,7 +86,7 @@ public class PointChargeConcurrencyTest {
         for (int i = 1; i <= threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    PointRequest pointRequest = createPointChargeRequest(50000L);
+                    PointRequest pointRequest = createPointChargeRequest(40000L);
                     pointChargeService.chargePoint(1L, pointRequest);
                     success.incrementAndGet();
                 } catch (IllegalStatusException e) {

--- a/src/test/java/com/hhplus/commerce/application/point/PointChargeConcurrencyTest.java
+++ b/src/test/java/com/hhplus/commerce/application/point/PointChargeConcurrencyTest.java
@@ -76,7 +76,7 @@ public class PointChargeConcurrencyTest {
 
     @Test
     @DisplayName("1명이 40000원씩 10번을 동시에 충전하면 2번 성공하고 8번 실패한다.")
-    void concurrentCharegForSamePoint10timesOverMax() throws InterruptedException {
+    void concurrentChargeForSamePoint10timesOverMax() throws InterruptedException {
         final int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -101,7 +101,6 @@ public class PointChargeConcurrencyTest {
 
         assertThat(success.get()).isEqualTo(2);
         assertThat(fail.get()).isEqualTo(8);
-
     }
 
     private PointRequest createPointChargeRequest(Long amount) {

--- a/src/test/java/com/hhplus/commerce/application/point/PointChargeConcurrencyTest.java
+++ b/src/test/java/com/hhplus/commerce/application/point/PointChargeConcurrencyTest.java
@@ -1,0 +1,126 @@
+package com.hhplus.commerce.application.point;
+
+import com.hhplus.commerce.application.point.dto.PointRequest;
+import com.hhplus.commerce.common.exception.IllegalStatusException;
+import com.hhplus.commerce.domain.customer.Customer;
+import com.hhplus.commerce.domain.customer.CustomerStore;
+import com.hhplus.commerce.domain.point.Point;
+import com.hhplus.commerce.domain.point.PointReader;
+import com.hhplus.commerce.domain.point.PointStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class PointChargeConcurrencyTest {
+    private final PointChargeService pointChargeService;
+    private final PointReader pointReader;
+    private final PointStore pointStore;
+    private final CustomerStore customerStore;
+
+    public PointChargeConcurrencyTest(
+            @Autowired PointChargeService pointChargeService,
+            @Autowired PointReader pointReader,
+            @Autowired PointStore pointStore,
+            @Autowired CustomerStore customerStore
+    ) {
+        this.pointChargeService = pointChargeService;
+        this.pointReader = pointReader;
+        this.pointStore = pointStore;
+        this.customerStore = customerStore;
+    }
+
+    @BeforeEach
+    void setUp() {
+        Customer customer = createCustomer(1L);
+        customerStore.save(customer);
+
+        Point point = createPoint(1L, 1L);
+        pointStore.save(point);
+    }
+
+    @Test
+    @DisplayName("1명이 100원씩 10번을 동시에 충전하면 총 1000원이 충전된다")
+    void concurrentChargeForSamePoint10times() throws InterruptedException {
+        final int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger success = new AtomicInteger(0);
+
+        for (int i = 1; i <= threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    PointRequest pointRequest = createPointChargeRequest(100L);
+                    pointChargeService.chargePoint(1L, pointRequest);
+                    success.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        assertThat(success.get()).isEqualTo(10);
+        assertThat(pointReader.getPoint(1L).getPoint()).isEqualTo(1000L);
+    }
+
+    @Test
+    @DisplayName("1명이 50000원씩 10번을 동시에 충전하면 2번 성공하고 8번 실패한다.")
+    void concurrentCharegForSamePoint10timesOverMax() throws InterruptedException {
+        final int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger success = new AtomicInteger(0);
+        AtomicInteger fail = new AtomicInteger(0);
+
+        for (int i = 1; i <= threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    PointRequest pointRequest = createPointChargeRequest(50000L);
+                    pointChargeService.chargePoint(1L, pointRequest);
+                    success.incrementAndGet();
+                } catch (IllegalStatusException e) {
+                    fail.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        assertThat(success.get()).isEqualTo(2);
+        assertThat(fail.get()).isEqualTo(8);
+
+    }
+
+    private PointRequest createPointChargeRequest(Long amount) {
+        return PointRequest.builder()
+                .amount(amount)
+                .build();
+    }
+
+    private Point createPoint(Long id, Long customerId) {
+        return Point.builder()
+                .id(id)
+                .customerId(customerId)
+                .point(0L)
+                .build();
+    }
+
+    private Customer createCustomer(Long id) {
+        return Customer.builder()
+                .id(id)
+                .build();
+    }
+}

--- a/src/test/java/com/hhplus/commerce/application/point/PointChargeServiceTest.java
+++ b/src/test/java/com/hhplus/commerce/application/point/PointChargeServiceTest.java
@@ -1,6 +1,6 @@
 package com.hhplus.commerce.application.point;
 
-import com.hhplus.commerce.application.point.dto.PointChargeRequest;
+import com.hhplus.commerce.application.point.dto.PointRequest;
 import com.hhplus.commerce.common.exception.EntityNotFoundException;
 import com.hhplus.commerce.common.exception.IllegalStatusException;
 import com.hhplus.commerce.domain.point.Point;
@@ -39,7 +39,7 @@ class PointChargeServiceTest {
             @DisplayName("포인트를 충전하고 충전된 금액을 반환한다")
             void it_charges_point_and_returns_charged_point() {
                 Point point = createPoint(existedCustomerId, 1000L);
-                PointChargeRequest request = createPointChargeRequest(5000L);
+                PointRequest request = createPointRequest(5000L);
                 given(pointReader.getPointWithPessimisticLock(existedCustomerId)).willReturn(point);
 
                 Long chargedPoint = pointChargeService.chargePoint(existedCustomerId, request);
@@ -56,7 +56,7 @@ class PointChargeServiceTest {
             @Test
             @DisplayName("포인트가 존재하지 않다는 예외를 반환한다")
             void it_throws_point_not_exists() {
-                PointChargeRequest request = createPointChargeRequest(5000L);
+                PointRequest request = createPointRequest(5000L);
                 given(pointReader.getPointWithPessimisticLock(notExistedCustomerId)).willThrow(EntityNotFoundException.class);
 
                 assertThatThrownBy(
@@ -75,7 +75,7 @@ class PointChargeServiceTest {
             @DisplayName("포인트가 최대를 초과했다는 예외를 반환한다.")
             void it_throws_point_overs_max() {
                 Point point = createPoint(existedCustomerId, 1000L);
-                PointChargeRequest request = createPointChargeRequest(5000000L);
+                PointRequest request = createPointRequest(5000000L);
                 given(pointReader.getPointWithPessimisticLock(existedCustomerId)).willReturn(point);
 
                 assertThatThrownBy(
@@ -93,8 +93,8 @@ class PointChargeServiceTest {
                 .build();
     }
 
-    private PointChargeRequest createPointChargeRequest(Long amount) {
-        return PointChargeRequest.builder()
+    private PointRequest createPointRequest(Long amount) {
+        return PointRequest.builder()
                 .amount(amount)
                 .build();
     }

--- a/src/test/java/com/hhplus/commerce/application/point/PointUseServiceTest.java
+++ b/src/test/java/com/hhplus/commerce/application/point/PointUseServiceTest.java
@@ -1,6 +1,6 @@
 package com.hhplus.commerce.application.point;
 
-import com.hhplus.commerce.application.point.dto.PointChargeRequest;
+import com.hhplus.commerce.application.point.dto.PointRequest;
 import com.hhplus.commerce.common.exception.EntityNotFoundException;
 import com.hhplus.commerce.common.exception.IllegalStatusException;
 import com.hhplus.commerce.domain.point.Point;
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -40,7 +39,7 @@ class PointUseServiceTest {
             @DisplayName("포인트를 사용하고 잔액을 반환한다")
             void it_uses_point_and_returns_left_point() {
                 Point point = createPoint(existedCustomerId, 5000L);
-                PointChargeRequest request = createPointChargeRequest(3000L);
+                PointRequest request = createPointChargeRequest(3000L);
                 given(pointReader.getPointWithPessimisticLock(existedCustomerId)).willReturn(point);
 
                 Long leftPoint = pointUseService.usePoint(existedCustomerId, request);
@@ -57,7 +56,7 @@ class PointUseServiceTest {
             @Test
             @DisplayName("포인트가 존재하지 않다는 예외를 반환한다")
             void it_throws_point_not_exists() {
-                PointChargeRequest request = createPointChargeRequest(5000L);
+                PointRequest request = createPointChargeRequest(5000L);
                 given(pointReader.getPointWithPessimisticLock(notExistedCustomerId)).willThrow(EntityNotFoundException.class);
 
                 assertThatThrownBy(
@@ -76,7 +75,7 @@ class PointUseServiceTest {
             @DisplayName("포인트가 최대를 초과했다는 예외를 반환한다.")
             void it_throws_point_insufficient() {
                 Point point = createPoint(existedCustomerId, 1000L);
-                PointChargeRequest request = createPointChargeRequest(5000000L);
+                PointRequest request = createPointChargeRequest(5000000L);
                 given(pointReader.getPointWithPessimisticLock(existedCustomerId)).willReturn(point);
 
                 assertThatThrownBy(
@@ -94,8 +93,8 @@ class PointUseServiceTest {
                 .build();
     }
 
-    private PointChargeRequest createPointChargeRequest(Long amount) {
-        return PointChargeRequest.builder()
+    private PointRequest createPointChargeRequest(Long amount) {
+        return PointRequest.builder()
                 .amount(amount)
                 .build();
     }


### PR DESCRIPTION
### Todo-list

- [x] 포인트 충전 동시성 테스트 추가
- [x] 재고 차감 동시성 테스트 추가
- [x] 통합 테스트

## 이번 과제 구현 방향  

### 동시성 테스트

- 재고 차감, 포인트 충전

재고 차감과 포인트 충전 모두 `비관적 락`을 사용해 DB 수준에서 잠금을 걸어 구현한다. JPA에서는 `@Lock(LockModeType.PESSIMISTIC_WRITE)`를 사용하여 쉽게 구현 가능하다. 락을 걸기 때문에 최대한 다른 비지니스에 영향을 주지 않기 위해 각각 재고 갯수와 포인트를 중점으로 테이블을 `정규화`한다.

---

### 테스트 Fixture 어떻게 만들까?

 테스트 Fixture를 어떤 방식으로 만들면 가독성 좋은 깔끔한 코드를 만들 수 있을지 굉장히 고민이 많았다. 가령 주문이나 결제를 테스트하면 주문 도메인, 결제 도메인, 상품 도메인, 포인트 도메인, 고객 도메인 등 대부분의 도메인의 테스트 객체를 만들어야 한다. 여러가지 방법들을 확인해보고 적용해 본다.  
  
### `@BeforeEach`에 만들기
  
- 적은 데이터는 괜찮으나 테스트 데이터가 길어질수록 가독성이 떨어진다.   
  
### TextFixture 파일에 공통 팩토리 만들기
  
- 별도의 파일에서 공통으로 사용하므로 코드양이 줄어드는 장점이 있다. 하지만 같은 객체의 팩토리가 계속 늘어난다면 혼란을 줄 수 있고 의도치 않게 다른 팩토리를 사용할 수도 있다.   

### 각 테스트파일마다 팩토리 만들기
  
 - 해당 파일에서만 사용할 수 있으므로 딱 필요한 팩토리만 사용하여 혼란이 줄어들고 가독성이 높아진다. 하지만 다른 파일에도 비슷한 기능이 필요하면 중복 코드를 작성하게 된다.  

### json 파일에 테스트 데이터 넣어두고 String 문자열로 변환하기

- 엄청나게 많은 객체들의 조합으로 이루어졌다면 간편하고 빠르게 데이터 구축이 가능하다. 하지만 json, 테스트코드 2가지 파일을 번갈아가면서 보아야 변수 확인이 가능하다.  

 테스트 객체를 만드는 방법은 결국 객체의 필드들을 모두 셋팅해주어야 한다. 나의경우 `각 테스트파일마다 팩토리`를 만들어 사용하였다. 팩토리 메서드는 맨 하단에 따로 빼서 사용하면 `@BeforeEach`, 전반적인 코드 가독성이 훨씬 가독성이 높아진다. 또한 생명주기를 공유하는 도메인들의 일관성을 위하여 aggregate를 사용하여 팩토리 네이밍을 했다. 다른 테스트코드 파일에서 만들어 둔 팩토리 메서드를 가져와서 재활용하니 생각보다 주문/결제같은 많은 비지니스가 있는 기능도 빠르게 셋팅할 수 있었다. json 파일로 만드는 방법도 흥미로웠으나 변환하는 코드를 짜기에는 시간이 촉박하여 성공하지 못했다. 

---

### @SpingBootTest에서 테스트하기

 목을 이용한 테스트는 쉽게 할 수 있는데, JPA를 활용하고 실제 데이터를 저장하는  `@SpringBootTest`는 아직 익숙하지 않다. `EntityManager`를 사용하지 않고 Repository를 그대로 이용하고 있는데 영속성 관련 문제들이 있는 것으로 보인다. 따라서 각 `@Test` 는 독립적으로 실행하는게 좋지만 `@Order`를 주어 원하는 순서대로 실행할 수 있도록 하였다. 더 좋은 방법이 있는지 확인이 필요하다. 

---

### 예외 코드의 통일

 이전에는 예외가 발생할때마다 하나씩 전부 예외 클래스를 만들었고 `@RestControllerAdvice` 에도 해당 예외 처리를 추가했다. 하지만 이제 `EntityNotFoundException`, `IllegalStatusException`, `InvalidParamException` 등 예외 상황은 최대한 공통으로 줄이고 `ErrorCode`를 활용한다. 각 예외의 매개변수로 `ErrorCode`를 넘겨주면 되는데 응답 형식은 토스 API를 참고하여 상태코드, 에러코드, 메세지를 응답한다.  enum 형식으로 저장하면 `ErroCode`에만 예외 상황을 추가하는 방식으로 편하게 관리 할 수 있다.

---

 ### 주문/결제 API 만들기

주문/결제 유스케이스 기획 흐름은 아래와 같습니다.

```
[주문]
- 재고 차감(비관적 락)
  -  재고 수량 검사
- 주문서 생성

[결제]
- 포인트 차감(비관적 락)
  - 포인트 부족 검사
- 결제 생성
  - 주문자와 결제자가 같은지 검사
  - 요청 결제 금액이 주문금액과 같은지 검사
  - 결제 가능한 상황인지 검사(결제완료인지 검사)
- 데이터 플랫폼 전송
```

`[주문]`과 `[결제]`는 `Facade`이고 세부 진행 사항은 `Service`로 구현했습니다. 중간 과정에 락을 이용하거나 유효성 검사가 있습니다. 이번 과제에서는 주문과 결제의 가장 중요한 DB 정보가 제대로 저장되는지 집중했습니다다. 

### 심화 고려사항
- 결제 요청 시, 멱등키를 부여하여 동일한 결제가 여러번 요청되었는지 검사하여 데이터 중복 생성을 방지
- 주문은 성공했지만 결제가 실패한 경우 주문 생성시간으로부터 15분 후에 주문을 취소한다.(스케쥴러로 1분마다 확인)

### 궁금한 점
- 주문과 결제가 단일 서버가 아니라 MSA 등의 환경일 경우 트랜잭션을 어떤 단위로 유지할 것인가? 전체 유스케이스를 하나의 트랜잭션으로 잡고 롤백이 생긴다면 다른 서버로 다 보상 트랜잭션을 마련해야 할까? 또 포인트 차감을 위해 `Point` 테이블에 접근해야하는데 다른 DB로 분리되어 있다면 비관적 락 사용이 안되지 않을까?