### PR TITLE
Step14_Redis 코드 적용

### DIFF
--- a/.testcontainers.properties
+++ b/.testcontainers.properties
@@ -1,0 +1,1 @@
+testcontainers.reuse.enable=true

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,17 @@ dependencies {
 	//reddison + redis
 	implementation 'org.redisson:redisson-spring-boot-starter:3.37.0'
 
+	//redis io/lettuce/core/AbstractRedisClient 에러 처리
+	implementation 'io.lettuce:lettuce-core'
+
+	//embedded redis(https://github.com/codemonstur/embedded-redis)
+	implementation 'com.github.codemonstur:embedded-redis:1.4.3'
+
+	// testcontainer
+	implementation "org.junit.jupiter:junit-jupiter:5.8.1"
+	implementation "org.testcontainers:testcontainers:1.20.3"
+	implementation "org.testcontainers:junit-jupiter:1.20.3"
+
 	//retry
 	implementation 'org.springframework.retry:spring-retry'
 }

--- a/src/main/java/com/hhplus/commerce/application/item/ItemBestQueryService.java
+++ b/src/main/java/com/hhplus/commerce/application/item/ItemBestQueryService.java
@@ -13,12 +13,16 @@ import java.util.List;
 public class ItemBestQueryService {
     private final OrderReader orderReader;
 
+    public List<ItemBestResponse> getBestItems() {
+        return orderReader.getBestItems();
+    }
+
     @Cacheable(
             cacheNames = "ItemBestQueryService:getBestItems",
             key = "'getBestItems'",
             cacheManager = "thirtyMinutesCacheManager"
     )
-    public List<ItemBestResponse> getBestItems() {
+    public List<ItemBestResponse> getBestItemsRedis() {
         return orderReader.getBestItems();
     }
 }

--- a/src/main/java/com/hhplus/commerce/application/payment/IdempotencyCheckService.java
+++ b/src/main/java/com/hhplus/commerce/application/payment/IdempotencyCheckService.java
@@ -1,5 +1,6 @@
 package com.hhplus.commerce.application.payment;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hhplus.commerce.application.payment.dto.PaymentIdempotencyCheckResponse;
 import com.hhplus.commerce.application.payment.dto.PaymentRequest;
 import com.hhplus.commerce.application.payment.dto.PaymentResponse;
@@ -12,10 +13,12 @@ import com.hhplus.commerce.domain.payment.PaymentReader;
 import com.hhplus.commerce.domain.payment.PaymentStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class IdempotencyCheckService {
+    private final ObjectMapper objectMapper;
     private final PaymentReader paymentReader;
     private final PaymentStore paymentStore;
 
@@ -75,5 +78,52 @@ public class IdempotencyCheckService {
                 && payment.getCustomerId().equals(paymentRequest.getCustomerId())
                 && payment.getOrderId().equals(paymentRequest.getOrderId())
                 && payment.getAmount().equals(paymentRequest.getAmount());
+    }
+
+    @Transactional
+    public PaymentIdempotencyCheckResponse idempotencyCheckRedis(PaymentRequest paymentRequest) {
+        //400 Bad Request 멱등키가 존재하지 않을 때
+        String requestIdempotencyKey = paymentRequest.getIdempotencyKey();
+        if (requestIdempotencyKey == null) {
+            throw new InvalidParamException(ErrorCode.PAYMENT_IDEMPOTENCY_KEY_INVALID);
+        }
+
+        // 멱등키에 결과 정보가 존재하지 않으면 결제 진행
+        Boolean valueIsAbsent = paymentStore.setIfAbsent(
+                requestIdempotencyKey,
+                "processing",
+                1L
+        );
+
+        if (valueIsAbsent.equals(true)) {
+            return PaymentIdempotencyCheckResponse.from(
+                    false,
+                    PaymentResponse.of(Payment.empty())
+            );
+        }
+
+        //409 Conflict 이미 요청을 처리중인데 동일한 요청을 했을 때
+        Object value = paymentReader.getPaymentByIdempotencyKeyRedis(requestIdempotencyKey);
+        if (value.toString().equals("processing")) {
+            throw new InvalidParamException(ErrorCode.PAYMENT_ALREADY_PROCESSING);
+        }
+
+        //422 Unprocessable Entity 재시도 된 요청 본문(payload)이 처음 요청과 다른데 같은 멱등키를 또 사용했을 때
+        PaymentResponse paymentResponse = objectMapper.convertValue(value, PaymentResponse.class);
+        if (!isSame(paymentResponse, paymentRequest)) {
+            throw new InvalidParamException(ErrorCode.PAYMENT_IDEMPOTENCY_KEY_INVALID);
+        }
+
+        return PaymentIdempotencyCheckResponse.from(
+                true,
+                paymentResponse
+        );
+    }
+
+    private boolean isSame(PaymentResponse paymentResponse, PaymentRequest paymentRequest) {
+        return paymentResponse.getPaymentMethod().equals(paymentRequest.getPaymentMethod())
+                && paymentResponse.getCustomerId().equals(paymentRequest.getCustomerId())
+                && paymentResponse.getOrderId().equals(paymentRequest.getOrderId())
+                && paymentResponse.getAmount().equals(paymentRequest.getAmount());
     }
 }

--- a/src/main/java/com/hhplus/commerce/application/payment/IdempotencyManageService.java
+++ b/src/main/java/com/hhplus/commerce/application/payment/IdempotencyManageService.java
@@ -1,0 +1,18 @@
+package com.hhplus.commerce.application.payment;
+
+import com.hhplus.commerce.application.payment.dto.PaymentResponse;
+import com.hhplus.commerce.domain.payment.PaymentStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class IdempotencyManageService {
+    private final PaymentStore paymentStore;
+
+    @Transactional
+    public void saveIdempotencyPayment(String idempotencyKey, PaymentResponse paymentResponse, Long expireMinute) {
+        paymentStore.savePaymentIdempotencyRedis(idempotencyKey, paymentResponse, expireMinute);
+    }
+}

--- a/src/main/java/com/hhplus/commerce/application/payment/PaymentFacade.java
+++ b/src/main/java/com/hhplus/commerce/application/payment/PaymentFacade.java
@@ -16,19 +16,26 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class PaymentFacade {
+    private static final Long EXPIRE_MINUTE_15 = 15L;
     private final PointUseService pointUseService;
     private final PaymentCreateService paymentCreateService;
     private final OrderQueryService orderQueryService;
     private final OrderStatusChangeService orderStatusChangeService;
     private final OrderDataPlatformSendService orderDataPlatformSendService;
     private final IdempotencyCheckService idempotencyCheckService;
+    private final IdempotencyManageService idempotencyManageService;
 
+    /**
+     * 분산락과 멱등성 DB로 결제한다
+     * @param paymentRequest 결제 요청
+     * @return 결제 응답
+     */
     @Transactional
     public PaymentResponse payOrder(PaymentRequest paymentRequest) {
         //멱등성 검사
         PaymentIdempotencyCheckResponse response = idempotencyCheckService.idempotencyCheck(paymentRequest);
         if (response.isIdempotencyKeyExists()) {
-            return response.getPayment();
+            return response.getPaymentResponse();
         }
 
         //포인트 차감
@@ -43,6 +50,40 @@ public class PaymentFacade {
 
         // 데이터 플랫폼 전송
         orderDataPlatformSendService.send(order);
+
+        return paymentResponse;
+    }
+
+    /**
+     * 분산락과 멱등성 Redis로 결제한다
+     * @param paymentRequest 결제 요청
+     * @return 결제 응답
+     */
+    @Transactional
+    public PaymentResponse payOrderRedis(PaymentRequest paymentRequest) {
+        //멱등성 검사
+        PaymentIdempotencyCheckResponse response = idempotencyCheckService.idempotencyCheckRedis(paymentRequest);
+        if (response.isIdempotencyKeyExists()) {
+            return response.getPaymentResponse();
+        }
+
+        //결제 저장
+        Order order = orderQueryService.getOrderWithPessimisticLock(paymentRequest.getOrderId());
+        PaymentResponse paymentResponse = paymentCreateService.createPayment(order, paymentRequest);
+
+        //포인트 차감
+        pointUseService.usePoint(paymentRequest.getCustomerId(), PointRequest.of(paymentRequest.getAmount()));
+
+        // 주문 완료
+        orderStatusChangeService.changeToComplete(order);
+
+        // 데이터 플랫폼 전송
+        orderDataPlatformSendService.send(order);
+
+        // 레디스에 <멱등성 키, 결제> 캐시 저장
+        idempotencyManageService.saveIdempotencyPayment(
+                paymentRequest.getIdempotencyKey(), paymentResponse, EXPIRE_MINUTE_15
+        );
 
         return paymentResponse;
     }

--- a/src/main/java/com/hhplus/commerce/application/payment/dto/PaymentIdempotencyCheckResponse.java
+++ b/src/main/java/com/hhplus/commerce/application/payment/dto/PaymentIdempotencyCheckResponse.java
@@ -13,12 +13,15 @@ public class PaymentIdempotencyCheckResponse {
     private boolean idempotencyKeyExists;
 
     @Schema(description = "결제 응답")
-    private PaymentResponse payment;
+    private PaymentResponse paymentResponse;
 
-    public static PaymentIdempotencyCheckResponse from(boolean idempotencyKeyExists, PaymentResponse paymentResponse) {
+    public static PaymentIdempotencyCheckResponse from(
+            boolean idempotencyKeyExists,
+            PaymentResponse paymentResponse
+    ) {
         return PaymentIdempotencyCheckResponse.builder()
                 .idempotencyKeyExists(idempotencyKeyExists)
-                .payment(paymentResponse)
+                .paymentResponse(paymentResponse)
                 .build();
     }
 }

--- a/src/main/java/com/hhplus/commerce/application/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/hhplus/commerce/application/payment/dto/PaymentResponse.java
@@ -7,11 +7,15 @@ import lombok.*;
 @Builder
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 @ToString
 @Schema(description = "결제 응답")
 public class PaymentResponse {
     @Schema(description = "결제 식별자", example = "10")
     private Long paymentId;
+
+    @Schema(description = "고객 식별자", example = "10")
+    private Long customerId;
 
     @Schema(description = "주문 식별자", example = "1")
     private Long orderId;
@@ -25,6 +29,7 @@ public class PaymentResponse {
     public static PaymentResponse of(Payment payment) {
         return PaymentResponse.builder()
                 .paymentId(payment.getId())
+                .customerId(payment.getCustomerId())
                 .orderId(payment.getOrderId())
                 .paymentMethod(payment.getPaymentMethod() == null? null : payment.getPaymentMethod().name())
                 .amount(payment.getAmount())

--- a/src/main/java/com/hhplus/commerce/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/hhplus/commerce/config/EmbeddedRedisConfig.java
@@ -1,0 +1,95 @@
+package com.hhplus.commerce.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.util.StringUtils;
+import redis.embedded.RedisServer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@Configuration
+public class EmbeddedRedisConfig {
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        int redisPort = isRedisRunning() ? findAvailablePort() : port;
+
+        redisServer = new RedisServer(redisPort);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() throws IOException {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    /**
+     * Embedded Redis가 현재 실행중인지 확인
+     */
+    private boolean isRedisRunning() throws IOException {
+        return isRunning(executeGrepProcessCommandMacLinux(port));
+    }
+
+    /**
+     * 현재 PC/서버에서 사용가능한 포트 조회
+     */
+    public int findAvailablePort() throws IOException {
+
+        for (int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommandWindow(port);
+            if (!isRunning(process)) {
+                return port;
+            }
+        }
+
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행(Window)
+     */
+    private Process executeGrepProcessCommandWindow(int port) throws IOException {
+        String command = String.format("netstat -nao | find \"LISTEN\" | find \"%d\"", port);
+        String[] shell = {"cmd.exe", "/y", "/c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행(Mac, Linux)
+     */
+    private Process executeGrepProcessCommandMacLinux(int port) throws IOException {
+        String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    /**
+     * 해당 Process가 현재 실행중인지 확인
+     */
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+
+        try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+
+            while ((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+
+        } catch (Exception e) {
+        }
+
+        return StringUtils.hasText(pidInfo.toString());
+    }
+}

--- a/src/main/java/com/hhplus/commerce/config/ObjectMapperConfig.java
+++ b/src/main/java/com/hhplus/commerce/config/ObjectMapperConfig.java
@@ -1,8 +1,6 @@
 package com.hhplus.commerce.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,10 +10,6 @@ public class ObjectMapperConfig {
     @Bean
     public ObjectMapper objectMapper() {
         return new ObjectMapper()
-                .findAndRegisterModules()
-                .enable(SerializationFeature.INDENT_OUTPUT)
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .registerModule(new JavaTimeModule());
     }
 }

--- a/src/main/java/com/hhplus/commerce/config/RedisContainersConfig.java
+++ b/src/main/java/com/hhplus/commerce/config/RedisContainersConfig.java
@@ -1,0 +1,27 @@
+package com.hhplus.commerce.config;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public class RedisContainersConfig implements BeforeAllCallback {
+    private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
+    private static final int REDIS_PORT = 6379;
+
+    @Container
+    public GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE))
+                    .withExposedPorts(REDIS_PORT)
+                    .withReuse(true);
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        redis.start();
+        System.setProperty("spring.data.redis.host", redis.getHost());
+        System.setProperty("spring.data.redis.port", String.valueOf(redis.getMappedPort(REDIS_PORT)));
+    }
+}

--- a/src/main/java/com/hhplus/commerce/domain/order/item/OrderItemOption.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/item/OrderItemOption.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "order_item_opionts")
+@Table(name = "order_item_options")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString

--- a/src/main/java/com/hhplus/commerce/domain/payment/Payment.java
+++ b/src/main/java/com/hhplus/commerce/domain/payment/Payment.java
@@ -37,4 +37,8 @@ public class Payment extends BaseTimeEntity {
         this.paymentMethod = paymentMethod;
         this.amount = amount;
     }
+
+    public static Payment empty() {
+        return Payment.builder().build();
+    }
 }

--- a/src/main/java/com/hhplus/commerce/domain/payment/PaymentIdempotency.java
+++ b/src/main/java/com/hhplus/commerce/domain/payment/PaymentIdempotency.java
@@ -34,14 +34,14 @@ public class PaymentIdempotency extends BaseTimeEntity {
         this.idempotencyKey = idempotencyKey;
     }
 
-    public boolean isIdempotencyKeySame(String idempotencyKey) {
-        return this.idempotencyKey.equals(idempotencyKey);
-    }
-
     public static PaymentIdempotency of(PaymentRequest paymentRequest) {
         return PaymentIdempotency.builder()
                 .idempotencyKey(paymentRequest.getIdempotencyKey())
                 .orderId(paymentRequest.getOrderId())
                 .build();
+    }
+
+    public boolean isIdempotencyKeySame(String idempotencyKey) {
+        return this.idempotencyKey.equals(idempotencyKey);
     }
 }

--- a/src/main/java/com/hhplus/commerce/domain/payment/PaymentReader.java
+++ b/src/main/java/com/hhplus/commerce/domain/payment/PaymentReader.java
@@ -6,4 +6,6 @@ public interface PaymentReader {
     boolean exists(Long orderId, String idempotencyKey);
 
     Payment getPayment(Long orderId);
+
+    Object getPaymentByIdempotencyKeyRedis(String key);
 }

--- a/src/main/java/com/hhplus/commerce/domain/payment/PaymentStore.java
+++ b/src/main/java/com/hhplus/commerce/domain/payment/PaymentStore.java
@@ -6,4 +6,8 @@ public interface PaymentStore {
     PaymentHistory saveOrderPaymentHistory(PaymentHistory paymentHistory);
 
     PaymentIdempotency savePaymentIdempotency(PaymentIdempotency paymentIdempotency);
+
+    Object savePaymentIdempotencyRedis(String key, Object value, Long expireMinute);
+
+    Boolean setIfAbsent(String key, Object value, Long expireMinute);
 }

--- a/src/main/java/com/hhplus/commerce/infra/payment/PaymentReaderImpl.java
+++ b/src/main/java/com/hhplus/commerce/infra/payment/PaymentReaderImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class PaymentReaderImpl implements PaymentReader {
     private final PaymentRepository paymentRepository;
     private final PaymentIdempotencyRepository paymentIdempotencyRepository;
+    private final PaymentRedisRepository paymentRedisRepository;
 
     @Override
     public PaymentIdempotency getPaymentIdempotency(Long orderId, String idempotencyKey) {
@@ -29,5 +30,10 @@ public class PaymentReaderImpl implements PaymentReader {
     public Payment getPayment(Long orderId) {
         return paymentRepository.findByOrderId(orderId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    @Override
+    public Object getPaymentByIdempotencyKeyRedis(String key) {
+        return paymentRedisRepository.findPaymentResponseByKey(key);
     }
 }

--- a/src/main/java/com/hhplus/commerce/infra/payment/PaymentRedisRepository.java
+++ b/src/main/java/com/hhplus/commerce/infra/payment/PaymentRedisRepository.java
@@ -1,0 +1,29 @@
+package com.hhplus.commerce.infra.payment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentRedisRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public Object findPaymentResponseByKey(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public Object setKeyValue(String key, Object value, Long expireMinute) {
+        redisTemplate.opsForValue().set(key, value);
+        redisTemplate.expire(key, expireMinute, TimeUnit.MINUTES);
+
+        return value;
+    }
+
+    public Boolean setIfAbsent(String key, Object value, Long expireMinute) {
+        return redisTemplate.opsForValue().setIfAbsent(key, value, Duration.ofMinutes(expireMinute));
+    }
+}

--- a/src/main/java/com/hhplus/commerce/infra/payment/PaymentStoreImpl.java
+++ b/src/main/java/com/hhplus/commerce/infra/payment/PaymentStoreImpl.java
@@ -1,9 +1,6 @@
 package com.hhplus.commerce.infra.payment;
 
-import com.hhplus.commerce.domain.payment.Payment;
-import com.hhplus.commerce.domain.payment.PaymentHistory;
-import com.hhplus.commerce.domain.payment.PaymentIdempotency;
-import com.hhplus.commerce.domain.payment.PaymentStore;
+import com.hhplus.commerce.domain.payment.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -15,6 +12,7 @@ public class PaymentStoreImpl implements PaymentStore {
     private final PaymentRepository paymentRepository;
     private final PaymentHistoryRepository paymentHistoryRepository;
     private final PaymentIdempotencyRepository paymentIdempotencyRepository;
+    private final PaymentRedisRepository paymentRedisRepository;
 
     @Override
     public Payment savePayment(Payment payment) {
@@ -30,5 +28,15 @@ public class PaymentStoreImpl implements PaymentStore {
     @Override
     public PaymentIdempotency savePaymentIdempotency(PaymentIdempotency paymentIdempotency) {
         return paymentIdempotencyRepository.save(paymentIdempotency);
+    }
+
+    @Override
+    public Object savePaymentIdempotencyRedis(String key, Object value, Long expireMinute) {
+        return paymentRedisRepository.setKeyValue(key, value, expireMinute);
+    }
+
+    @Override
+    public Boolean setIfAbsent(String key, Object value, Long expireMinute) {
+        return paymentRedisRepository.setIfAbsent(key, value, expireMinute);
     }
 }

--- a/src/main/java/com/hhplus/commerce/interfaces/item/ItemApiController.java
+++ b/src/main/java/com/hhplus/commerce/interfaces/item/ItemApiController.java
@@ -29,6 +29,13 @@ public class ItemApiController implements ItemApiSpecification {
         return CommonResponse.success(itemResponse);
     }
     
+    @GetMapping("/best/r")
+    public CommonResponse getBestItemsRedis() {
+        List<ItemBestResponse> bestItems = itemBestQueryService.getBestItemsRedis();
+
+        return CommonResponse.success(bestItems);
+    }
+
     @GetMapping("/best")
     public CommonResponse getBestItems() {
         List<ItemBestResponse> bestItems = itemBestQueryService.getBestItems();

--- a/src/main/java/com/hhplus/commerce/interfaces/payment/PaymentDto.java
+++ b/src/main/java/com/hhplus/commerce/interfaces/payment/PaymentDto.java
@@ -1,15 +1,13 @@
 package com.hhplus.commerce.interfaces.payment;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 
 public class PaymentDto {
     @Builder
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     @ToString
     @Schema(description = "결제 요청")
     public static class PayOrderRequest {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,17 @@
+#spring:
+#  profiles:
+#    active: prod
+
 spring:
   data:
     redis:
       host: localhost
       port: 6379
-#  datasource:
-#    url: jdbc:h2:tcp://localhost/~/test
-#    username: sa
-#    password:
-#    driver-class-name: org.h2.Driver
+  #  datasource:
+  #    url: jdbc:h2:tcp://localhost/~/test
+  #    username: sa
+  #    password:
+  #    driver-class-name: org.h2.Driver
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/mydb?serverTimezone=UTC&characterEncoding=UTF-8
@@ -17,9 +21,9 @@ spring:
   sql:
     init:
       mode: always # 서버 시작시 항상 classpath의 sql문을 실행하도록 설정
-#      continue-on-error: true # 서버 시작시 sql문을 실행할 때 오류 무시하고 계속 진행
-#      schema-locations: classpath:sql/schema-postgresql.sql # 서버 시작시 ddl sql문을 실행할 위치 및 파일 지정
-#      data-locations: classpath:sql/data.sql # 서버 시작시 dml sql문을 실행할 위치 및 파일 지정
+  #      continue-on-error: true # 서버 시작시 sql문을 실행할 때 오류 무시하고 계속 진행
+  #      schema-locations: classpath:sql/schema-postgresql.sql # 서버 시작시 ddl sql문을 실행할 위치 및 파일 지정
+  #      data-locations: classpath:sql/data.sql # 서버 시작시 dml sql문을 실행할 위치 및 파일 지정
 
   jpa:
     defer-datasource-initialization: true
@@ -28,7 +32,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-#        dialect: org.hibernate.dialect.H2Dialect
+        #        dialect: org.hibernate.dialect.H2Dialect
         dialect: org.hibernate.dialect.MySQLDialect
     show-sql: true
     database-platform: org.hibernate.dialect.MySQLDialect

--- a/src/test/java/com/hhplus/commerce/application/payment/PaymentFacadeTest.java
+++ b/src/test/java/com/hhplus/commerce/application/payment/PaymentFacadeTest.java
@@ -4,6 +4,7 @@ import com.hhplus.commerce.application.payment.dto.PaymentRequest;
 import com.hhplus.commerce.common.exception.IllegalStatusException;
 import com.hhplus.commerce.common.exception.InvalidParamException;
 import com.hhplus.commerce.common.response.ErrorCode;
+import com.hhplus.commerce.config.RedisContainersConfig;
 import com.hhplus.commerce.domain.customer.Customer;
 import com.hhplus.commerce.domain.customer.CustomerStore;
 import com.hhplus.commerce.domain.order.Order;
@@ -27,6 +28,7 @@ import com.hhplus.commerce.infra.payment.PaymentIdempotencyRepository;
 import com.hhplus.commerce.infra.payment.PaymentRepository;
 import com.hhplus.commerce.infra.point.PointRepository;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -39,6 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@ExtendWith(RedisContainersConfig.class)
 @SpringBootTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class PaymentFacadeTest {
@@ -217,7 +220,7 @@ public class PaymentFacadeTest {
                 order.getId(), customer.getId(), "TOSS", 10000L, "123"
         );
 
-        final int threadCount = 5;
+        final int threadCount = 100;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
         AtomicInteger success = new AtomicInteger(0);
@@ -230,7 +233,7 @@ public class PaymentFacadeTest {
                     if (finalI > 1) {
                         Thread.sleep(1000L);
                     }
-                    paymentFacade.payOrder(paymentRequest);
+                    paymentFacade.payOrderRedis(paymentRequest);
                     success.incrementAndGet();
                 } catch (Exception e) {
                     fail.incrementAndGet();

--- a/src/test/java/com/hhplus/commerce/infra/payment/PaymentRedisRepositoryTest.java
+++ b/src/test/java/com/hhplus/commerce/infra/payment/PaymentRedisRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.hhplus.commerce.infra.payment;
+
+import com.hhplus.commerce.config.RedisContainersConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(RedisContainersConfig.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PaymentRedisRepositoryTest {
+    @Autowired
+    TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private RedisTemplate redisTemplate;
+
+    @Autowired
+    private PaymentRedisRepository paymentRedisRepository;
+
+    @Test
+    void hello() {
+        String fooResource = "/foo";
+
+        testRestTemplate.put(fooResource, "bar");
+
+        assertThat(testRestTemplate.getForObject(fooResource, String.class))
+                .as("value is set")
+                .isEqualTo("bar");
+    }
+
+    @Test
+    void hello2() {
+        redisTemplate.opsForValue().set("hi", "bar");
+
+        assertThat(redisTemplate.opsForValue().get("hi")).isEqualTo("bar");
+    }
+
+    @Test
+    void hello3() {
+        paymentRedisRepository.setKeyValue("key", "value", 30L);
+
+        Object value = paymentRedisRepository.findPaymentResponseByKey("key");
+
+        assertThat(value).isEqualTo("value");
+    }
+}


### PR DESCRIPTION
## Redis 설정하기
Redis의 `TTL`을 쉽게 `@Cacheable`에서 설정하기 위해 `CacheManager`를 생성합니다. 원하는 시간을 `CacheManager`를 만들어 `@Cacheable`에 추가합니다. 

```java
@Bean
public CacheManager thirtyMinutesCacheManager() {
    return RedisCacheManager.builder(connectionFactory)
            .cacheDefaults(thirtyMinutesCache())
            .build();
}

private RedisCacheConfiguration thirtyMinutesCache() {
    return RedisCacheConfiguration.defaultCacheConfig()
            .serializeKeysWith(fromSerializer(new StringRedisSerializer()))
            .serializeValuesWith(fromSerializer(new Jackson2JsonRedisSerializer<>(Object.class)))
            .entryTtl(Duration.ofMinutes(THIRTY_MINUTE));
}

...

@Cacheable(
        cacheNames = "ItemBestQueryService:getBestItems",
        key = "'getBestItems'",
        cacheManager = "thirtyMinutesCacheManager"
)
public List<ItemBestResponse> getBestItemsRedis() {
    return orderReader.getBestItems();
}
```

## Redis template으로 저장소 이용하기
`Redistemplate`을 사용하면 Redis의 다양한 자료구조를 사용할 수 있습니다.  직렬화/역직렬화를 위해 `StringRedisSerializer`와 `Jackson2JsonRedisSerializer`를 사용합니다.

```java
@Bean
public RedisTemplate<String, Object> redisTemplate() {
    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
    redisTemplate.setKeySerializer(new StringRedisSerializer());
    redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
    redisTemplate.setConnectionFactory(redisConnectionFactory());
    return redisTemplate;
}

...

@Bean
public RedisConnectionFactory redisConnectionFactory() {
    return new LettuceConnectionFactory(host, port);
}
```

## Redis 테스트하기

### 1. 로컬 캐시 사용하기
 테스트동안 사용 할 전용 로컬 캐시를 띄웁니다. 자동으로 캐시를 실행시키기 위해 비어있는 포트를 검사해야하며 시작 명령어를 준비합니다. (윈도우와 맥/Linux의 명령어가 다름) 별다른 추가 설정 없이 가능합니다.

### 2. Docker로 띄운 Redis에 연결하기
 로컬이 아닌 Docker에 띄운 Redis 서버를 연결합니다. host, port를 해당 도커의 redis에 맞게 설정하면 됩니다. 테스트를 하지 않아도 계속 Docker에서 Redis를 사용할 수 있습니다.  

### 3. TestContainer로 테스트마다 Redis 활용하기
 테스트동안 Docker에 Redis를 띄우며 테스트가 끝나면 자동으로 Redis를 종료합니다. 개발자가 별도로 준비과정 코드를 많이 작성하지 않아도 host, port만 잘 연결하면 내부에서 자동으로 설정되는 효과가 있어 사용이 간편합니다.

 이번에 TestContainer를 경험하려고 사용했습니다. 컨테이너 설정 및 host, port만 설정한 간단한 코드였는데 알아서 Docker를 활용해 Redis를 띄워주는 간편한 환경을 경험 할 수 있었습니다.

```java
@Testcontainers
public class RedisContainersConfig implements BeforeAllCallback {
    private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
    private static final int REDIS_PORT = 6379;

    @Container
    public GenericContainer<?> redis =
            new GenericContainer<>(DockerImageName.parse(REDIS_IMAGE))
                    .withExposedPorts(REDIS_PORT)
                    .withReuse(true);

    @Override
    public void beforeAll(ExtensionContext context) {
        redis.start();
        System.setProperty("spring.data.redis.host", redis.getHost());
        System.setProperty("spring.data.redis.port", String.valueOf(redis.getMappedPort(REDIS_PORT)));
    }
}
```