### PR TITLE
Step18_카프카 메시징 사용

### DIFF
--- a/src/main/java/com/hhplus/commerce/application/order/OrderExternalEventService.java
+++ b/src/main/java/com/hhplus/commerce/application/order/OrderExternalEventService.java
@@ -1,0 +1,33 @@
+package com.hhplus.commerce.application.order;
+
+import com.hhplus.commerce.domain.order.OrderExternalEventReader;
+import com.hhplus.commerce.domain.order.OrderExternalEventStore;
+import com.hhplus.commerce.domain.outbox.OutBoxCommand;
+import com.hhplus.commerce.domain.outbox.Outbox;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderExternalEventService {
+    private final OrderExternalEventStore eventStore;
+    private final OrderExternalEventReader eventReader;
+
+    public void create(OutBoxCommand.SaveRequest request) {
+        eventStore.save(request.toEntity());
+    }
+
+    public List<Outbox> findAll(OutBoxCommand.FindAllRequest request) {
+        return eventReader.findAllNotProcessedByTopic(request);
+    }
+
+    public void changeToProcessedTrue(Outbox outbox) {
+        outbox.changeToProcessedTrue();
+    }
+
+    public Outbox findOutbox(OutBoxCommand.FindRequest request) {
+        return eventReader.findByTopicAndMessage(request);
+    }
+}

--- a/src/main/java/com/hhplus/commerce/application/order/OrderFacade.java
+++ b/src/main/java/com/hhplus/commerce/application/order/OrderFacade.java
@@ -1,10 +1,13 @@
 package com.hhplus.commerce.application.order;
 
 import com.hhplus.commerce.application.item.ItemStockService;
+import com.hhplus.commerce.application.order.dataPlatform.OrderDataPlatformEvent;
 import com.hhplus.commerce.application.order.kafkaSample.OrderSampleKafkaService;
 import com.hhplus.commerce.domain.order.Order;
 import com.hhplus.commerce.domain.order.OrderCommand;
 import com.hhplus.commerce.domain.order.OrderInfo;
+import com.hhplus.commerce.domain.outbox.OutBoxCommand;
+import com.hhplus.commerce.domain.outbox.Outbox;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +17,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static com.hhplus.commerce.domain.order.Order.PAY_CHECK_MINUTE;
+import static com.hhplus.commerce.domain.outbox.Outbox.PROCESSED_CHECK_MINUTE;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +27,8 @@ public class OrderFacade {
     private final OrderQueryService orderQueryService;
     private final OrderCancelHandler orderCancelHandler;
     private final OrderSampleKafkaService orderSampleKafkaService;
+    private final OrderExternalEventService orderExternalEventService;
+    private final OrderDataPlatformManageService orderDataPlatformManageService;
 
     @Transactional
     public OrderInfo.CreateResponse orderPessimisticLock(OrderCommand.OrderRequest request) {
@@ -89,11 +95,40 @@ public class OrderFacade {
     }
 
     @Transactional
-    public void orderCancelWithTime(int minute, LocalDateTime dateTime) {
+    public void orderCancelWithParam(int minute, LocalDateTime dateTime) {
         List<Order> orders = orderQueryService.getInitOrders();
 
         orders.forEach(order -> {
             orderCancelHandler.cancelOrder(order, dateTime, minute);
+        });
+    }
+
+    //@Scheduled(cron = "0 * * * * *")
+    @Transactional
+    public void orderExternalEventOrderDataPlatformSendBatch() {
+        OutBoxCommand.FindAllRequest request = OutBoxCommand.FindAllRequest.of(
+                OrderDataPlatformEvent.ORDER_DATA_PLATFORM_EVENT_V1_TOPIC, false
+        );
+        List<Outbox> outboxes = orderExternalEventService.findAll(request);
+
+        outboxes.forEach(outbox -> {
+            if (outbox.getCreatedDate().plusMinutes(PROCESSED_CHECK_MINUTE).isAfter(LocalDateTime.now())) {
+                orderDataPlatformManageService.send(OrderCommand.OrderDataPlatformRequest.of(outbox.getMessage()));
+                orderExternalEventService.changeToProcessedTrue(outbox);
+            }
+        });
+    }
+
+    @Transactional
+    public void orderExternalEventOrderDataPlatformSendWithParam(String topic, boolean processed, int minute, LocalDateTime dateTime) {
+        OutBoxCommand.FindAllRequest request = OutBoxCommand.FindAllRequest.of(topic, processed);
+        List<Outbox> outboxes = orderExternalEventService.findAll(request);
+
+        outboxes.forEach(outbox -> {
+            if (outbox.getCreatedDate().plusMinutes(minute).isAfter(dateTime)) {
+                orderDataPlatformManageService.send(OrderCommand.OrderDataPlatformRequest.of(outbox.getMessage()));
+                orderExternalEventService.changeToProcessedTrue(outbox);
+            }
         });
     }
 

--- a/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformConsumer.java
+++ b/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformConsumer.java
@@ -1,0 +1,34 @@
+package com.hhplus.commerce.application.order.dataPlatform;
+
+import com.hhplus.commerce.application.order.OrderDataPlatformManageService;
+import com.hhplus.commerce.application.order.OrderExternalEventService;
+import com.hhplus.commerce.domain.order.OrderCommand;
+import com.hhplus.commerce.domain.outbox.OutBoxCommand;
+import com.hhplus.commerce.domain.outbox.Outbox;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderDataPlatformConsumer {
+    private final OrderDataPlatformManageService orderDataPlatformManageService;
+    private final OrderExternalEventService orderExternalEventService;
+
+    @Transactional
+    @KafkaListener(topics = OrderDataPlatformEvent.ORDER_DATA_PLATFORM_EVENT_V1_TOPIC, groupId = "group_2")
+    public void orderDataPlatformHandler(OrderDataPlatformEvent event) {
+        log.info("topic {}, message: {}", OrderDataPlatformEvent.ORDER_DATA_PLATFORM_EVENT_V1_TOPIC, event);
+        OrderDataPlatformPayload orderDataPlatformPayload = OrderDataPlatformPayload.of(event);
+        orderDataPlatformManageService.send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload));
+
+        OutBoxCommand.FindRequest command = OutBoxCommand.FindRequest.of(
+                OrderDataPlatformEvent.ORDER_DATA_PLATFORM_EVENT_V1_TOPIC, String.valueOf(event.getOrderId())
+        );
+        Outbox outbox = orderExternalEventService.findOutbox(command);
+        orderExternalEventService.changeToProcessedTrue(outbox);
+    }
+}

--- a/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformEvent.java
+++ b/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformEvent.java
@@ -1,11 +1,17 @@
 package com.hhplus.commerce.application.order.dataPlatform;
 
 import com.hhplus.commerce.domain.order.Order;
+import com.hhplus.commerce.domain.outbox.OutBoxCommand;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class OrderDataPlatformEvent {
+    public static final String ORDER_DOMAIN_NAME = "order";
+    public static final String ORDER_DATA_PLATFORM_EVENT_V1_TOPIC = "order-data-platform-event-v1";
+    public static final String ORDER_DATA_PLATFORM_EVENT_TYPE = "orderDataPlatform";
+    public static final String ORDER_DATA_PLATFORM_EVENT = "orderDataPlatform";
+
     private final Long orderId;
 
     @Builder
@@ -16,6 +22,16 @@ public class OrderDataPlatformEvent {
     public static OrderDataPlatformEvent of(Order order) {
         return OrderDataPlatformEvent.builder()
                 .orderId(order.getId())
+                .build();
+    }
+
+    public OutBoxCommand.SaveRequest toSaveRequestCommand() {
+        return OutBoxCommand.SaveRequest.builder()
+                .domainName(ORDER_DOMAIN_NAME)
+                .topic(ORDER_DATA_PLATFORM_EVENT_V1_TOPIC)
+                .eventType(ORDER_DATA_PLATFORM_EVENT_TYPE)
+                .message(String.valueOf(orderId))
+                .processed(false)
                 .build();
     }
 }

--- a/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformListener.java
+++ b/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformListener.java
@@ -3,20 +3,17 @@ package com.hhplus.commerce.application.order.dataPlatform;
 import com.hhplus.commerce.application.order.OrderDataPlatformManageService;
 import com.hhplus.commerce.domain.order.OrderCommand;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class OrderDataPlatformListener {
     private final OrderDataPlatformManageService orderDataPlatformManageService;
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+//    @Async
+//    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void orderDataPlatformHandler(OrderDataPlatformEvent event) {
         OrderDataPlatformPayload orderDataPlatformPayload = OrderDataPlatformPayload.of(event);
-        orderDataPlatformManageService.send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload.getOrderId()));
+        orderDataPlatformManageService.send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload));
     }
 }

--- a/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformMessageListener.java
+++ b/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformMessageListener.java
@@ -1,0 +1,20 @@
+package com.hhplus.commerce.application.order.dataPlatform;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class OrderDataPlatformMessageListener {
+    private final KafkaTemplate<String, OrderDataPlatformEvent> kafkaTemplate;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void success(OrderDataPlatformEvent event) {
+        kafkaTemplate.send(OrderDataPlatformEvent.ORDER_DATA_PLATFORM_EVENT_V1_TOPIC, event);
+    }
+}

--- a/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformRecordListener.java
+++ b/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformRecordListener.java
@@ -1,0 +1,19 @@
+package com.hhplus.commerce.application.order.dataPlatform;
+
+import com.hhplus.commerce.application.order.OrderExternalEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class OrderDataPlatformRecordListener {
+    private final OrderExternalEventService orderExternalEventService;
+
+    // 아웃박스 테이블에 주문완료 이벤트 기록
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void OrderCompletedRecordHandler(OrderDataPlatformEvent event) {
+        orderExternalEventService.create(event.toSaveRequestCommand());
+    }
+}

--- a/src/main/java/com/hhplus/commerce/application/payment/IdempotencyCheckService.java
+++ b/src/main/java/com/hhplus/commerce/application/payment/IdempotencyCheckService.java
@@ -1,15 +1,15 @@
 package com.hhplus.commerce.application.payment;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hhplus.commerce.support.distributedLock.DistributedLock;
-import com.hhplus.commerce.support.exception.InvalidParamException;
-import com.hhplus.commerce.support.response.ErrorCode;
 import com.hhplus.commerce.domain.payment.Payment;
 import com.hhplus.commerce.domain.payment.PaymentCommand;
 import com.hhplus.commerce.domain.payment.PaymentInfo;
 import com.hhplus.commerce.domain.payment.PaymentReader;
 import com.hhplus.commerce.domain.payment.PaymentStore;
 import com.hhplus.commerce.domain.payment.idempotency.PaymentIdempotency;
+import com.hhplus.commerce.support.distributedLock.DistributedLock;
+import com.hhplus.commerce.support.exception.InvalidParamException;
+import com.hhplus.commerce.support.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +21,7 @@ public class IdempotencyCheckService {
     private final PaymentReader paymentReader;
     private final PaymentStore paymentStore;
 
-    @DistributedLock(key = "'idempotencyKey'.concat(':').concat(#paymentRequest.getIdempotencyKey())")
+    @DistributedLock(key = "'idempotencyKey'.concat(':').concat(#payOrderRequest.getOrderId())")
     public PaymentInfo.PaymentIdempotencyCheckResponse idempotencyCheck(PaymentCommand.PayOrderRequest payOrderRequest) {
         //400 Bad Request 멱등키가 존재하지 않을 때
         String requestIdempotencyKey = payOrderRequest.getIdempotencyKey();

--- a/src/main/java/com/hhplus/commerce/application/payment/PaymentFacade.java
+++ b/src/main/java/com/hhplus/commerce/application/payment/PaymentFacade.java
@@ -84,15 +84,15 @@ public class PaymentFacade {
         );
         pointUseService.usePoint(command);
 
-        // 주문 완료
-        orderStatusChangeService.changeToComplete(order);
-
         // 레디스에 <멱등성 키, 결제> 캐시 저장
         idempotencyManageService.saveIdempotencyPayment(
                 payOrderRequest.getIdempotencyKey(), paymentResponse, EXPIRE_MINUTE_15
         );
 
-        // 데이터 플랫폼 전송 이벤트
+        // 주문 완료
+        orderStatusChangeService.changeToComplete(order);
+
+        // 데이터 플랫폼 전송 이벤트 -> 트랜잭셔널 아웃박스 패턴
         orderDataPlatformPublisher.success(OrderDataPlatformEvent.of(order));
 
         if (type.equals("1")) {

--- a/src/main/java/com/hhplus/commerce/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/hhplus/commerce/config/KafkaConsumerConfig.java
@@ -1,5 +1,6 @@
 package com.hhplus.commerce.config;
 
+import com.hhplus.commerce.application.order.dataPlatform.OrderDataPlatformEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -35,6 +36,23 @@ public class KafkaConsumerConfig {
     public ConcurrentKafkaListenerContainerFactory<String, Long> kafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, Long> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, OrderDataPlatformEvent> consumerOrderDataPlatformFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, host + ":" + port);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "group_2");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, OrderDataPlatformEvent> kafkaOrderDataPlatformListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, OrderDataPlatformEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerOrderDataPlatformFactory());
         return factory;
     }
 }

--- a/src/main/java/com/hhplus/commerce/config/KafkaProducerConfig.java
+++ b/src/main/java/com/hhplus/commerce/config/KafkaProducerConfig.java
@@ -1,6 +1,7 @@
 package com.hhplus.commerce.config;
 
 
+import com.hhplus.commerce.application.order.dataPlatform.OrderDataPlatformEvent;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -34,5 +35,19 @@ public class KafkaProducerConfig {
     @Bean
     public KafkaTemplate<String, Long> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, OrderDataPlatformEvent> producerOrderDataPlatformFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, host + ":" + port);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, OrderDataPlatformEvent> kafkaOrderDataPlatformTemplate() {
+        return new KafkaTemplate<>(producerOrderDataPlatformFactory());
     }
 }

--- a/src/main/java/com/hhplus/commerce/domain/order/OrderCommand.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/OrderCommand.java
@@ -1,11 +1,13 @@
 package com.hhplus.commerce.domain.order;
 
+import com.hhplus.commerce.application.order.dataPlatform.OrderDataPlatformPayload;
 import com.hhplus.commerce.domain.order.address.Address;
 import com.hhplus.commerce.domain.order.item.OrderItem;
 import com.hhplus.commerce.domain.order.item.OrderItemOption;
 import com.hhplus.commerce.interfaces.order.OrderDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -19,12 +21,19 @@ public class OrderCommand {
     @NoArgsConstructor
     @AllArgsConstructor
     @ToString
+    @EqualsAndHashCode(of = "orderId")
     public static class OrderDataPlatformRequest {
         private Long orderId;
 
-        public static OrderDataPlatformRequest of(Long orderId) {
+        public static OrderDataPlatformRequest of(OrderDataPlatformPayload event) {
             return OrderDataPlatformRequest.builder()
-                    .orderId(orderId)
+                    .orderId(event.getOrderId())
+                    .build();
+        }
+
+        public static OrderDataPlatformRequest of(String orderId) {
+            return OrderDataPlatformRequest.builder()
+                    .orderId(Long.valueOf(orderId))
                     .build();
         }
     }

--- a/src/main/java/com/hhplus/commerce/domain/order/OrderExternalEventReader.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/OrderExternalEventReader.java
@@ -1,0 +1,12 @@
+package com.hhplus.commerce.domain.order;
+
+import com.hhplus.commerce.domain.outbox.OutBoxCommand;
+import com.hhplus.commerce.domain.outbox.Outbox;
+
+import java.util.List;
+
+public interface OrderExternalEventReader {
+    List<Outbox> findAllNotProcessedByTopic(OutBoxCommand.FindAllRequest request);
+
+    Outbox findByTopicAndMessage(OutBoxCommand.FindRequest request);
+}

--- a/src/main/java/com/hhplus/commerce/domain/order/OrderExternalEventStore.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/OrderExternalEventStore.java
@@ -1,0 +1,7 @@
+package com.hhplus.commerce.domain.order;
+
+import com.hhplus.commerce.domain.outbox.Outbox;
+
+public interface OrderExternalEventStore {
+    void save(Outbox outbox);
+}

--- a/src/main/java/com/hhplus/commerce/domain/outbox/OutBoxCommand.java
+++ b/src/main/java/com/hhplus/commerce/domain/outbox/OutBoxCommand.java
@@ -1,0 +1,62 @@
+package com.hhplus.commerce.domain.outbox;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class OutBoxCommand {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SaveRequest {
+        private String domainName;
+        private String topic;
+        private String eventType;
+        private String message;
+        private boolean processed;
+
+        public Outbox toEntity() {
+            return Outbox.builder()
+                    .domainName(domainName)
+                    .topic(topic)
+                    .eventType(eventType)
+                    .message(message)
+                    .processed(processed)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FindAllRequest {
+        private String topic;
+        private boolean processed;
+
+        public static FindAllRequest of(String topic, boolean processed) {
+            return FindAllRequest.builder()
+                    .topic(topic)
+                    .processed(processed)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FindRequest {
+        private String topic;
+        private String message;
+
+        public static FindRequest of(String topic, String message) {
+            return FindRequest.builder()
+                    .topic(topic)
+                    .message(message)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/hhplus/commerce/domain/outbox/Outbox.java
+++ b/src/main/java/com/hhplus/commerce/domain/outbox/Outbox.java
@@ -1,0 +1,68 @@
+package com.hhplus.commerce.domain.outbox;
+
+import com.hhplus.commerce.support.BaseTimeEntity;
+import com.hhplus.commerce.support.exception.IllegalStatusException;
+import com.hhplus.commerce.support.response.ErrorCode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "outbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class Outbox extends BaseTimeEntity {
+    public static final int PROCESSED_CHECK_MINUTE = 15;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 발신자 order
+    private String domainName;
+
+    //수신자 order-data-platform-event-v1
+    private String topic;
+
+    //제목 orderDataPlatform
+    private String eventType;
+
+    //내용 json형태 같은 것
+    private String message;
+
+    //발송완료 false
+    private boolean processed = false;
+
+    @Builder
+    public Outbox(
+            Long id,
+            String domainName,
+            String topic,
+            String eventType,
+            String message,
+            boolean processed
+    ) {
+        this.id = id;
+        this.domainName = domainName;
+        this.topic = topic;
+        this.eventType = eventType;
+        this.message = message;
+        this.processed = processed;
+    }
+
+    public void changeToProcessedTrue() {
+        if (processed) {
+            throw new IllegalStatusException(ErrorCode.COMMON_ILLEGAL_STATUS);
+        }
+
+        processed = true;
+    }
+}

--- a/src/main/java/com/hhplus/commerce/infra/outbox/OrderExternalEventReaderImpl.java
+++ b/src/main/java/com/hhplus/commerce/infra/outbox/OrderExternalEventReaderImpl.java
@@ -1,0 +1,28 @@
+package com.hhplus.commerce.infra.outbox;
+
+import com.hhplus.commerce.domain.order.OrderExternalEventReader;
+import com.hhplus.commerce.domain.outbox.OutBoxCommand;
+import com.hhplus.commerce.domain.outbox.Outbox;
+import com.hhplus.commerce.support.exception.EntityNotFoundException;
+import com.hhplus.commerce.support.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OrderExternalEventReaderImpl implements OrderExternalEventReader {
+    private final OutboxRepository outboxRepository;
+
+    @Override
+    public List<Outbox> findAllNotProcessedByTopic(OutBoxCommand.FindAllRequest request) {
+        return outboxRepository.findAllNotProcessedByTopic(request.getTopic(), request.isProcessed());
+    }
+
+    @Override
+    public Outbox findByTopicAndMessage(OutBoxCommand.FindRequest request) {
+        return outboxRepository.findByTopicAndMessage(request.getTopic(), request.getMessage())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.OUTBOX_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/hhplus/commerce/infra/outbox/OrderExternalEventStoreImpl.java
+++ b/src/main/java/com/hhplus/commerce/infra/outbox/OrderExternalEventStoreImpl.java
@@ -1,0 +1,17 @@
+package com.hhplus.commerce.infra.outbox;
+
+import com.hhplus.commerce.domain.order.OrderExternalEventStore;
+import com.hhplus.commerce.domain.outbox.Outbox;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderExternalEventStoreImpl implements OrderExternalEventStore {
+    private final OutboxRepository outboxRepository;
+
+    @Override
+    public void save(Outbox outbox) {
+        outboxRepository.save(outbox);
+    }
+}

--- a/src/main/java/com/hhplus/commerce/infra/outbox/OutboxRepository.java
+++ b/src/main/java/com/hhplus/commerce/infra/outbox/OutboxRepository.java
@@ -1,0 +1,16 @@
+package com.hhplus.commerce.infra.outbox;
+
+import com.hhplus.commerce.domain.outbox.Outbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OutboxRepository extends JpaRepository<Outbox, Long> {
+    @Query(value = "select o from Outbox o where o.topic = :topic and o.processed = :processed")
+    List<Outbox> findAllNotProcessedByTopic(@Param("topic") String topic, @Param("processed") boolean processed);
+
+    Optional<Outbox> findByTopicAndMessage(@Param("topic")String topic, @Param("message")String message);
+}

--- a/src/main/java/com/hhplus/commerce/support/response/ErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/support/response/ErrorCode.java
@@ -47,6 +47,9 @@ public enum ErrorCode {
     //cart
     CART_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 장바구니 입니다."),
 
+    //outbox
+    OUTBOX_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이벤트 데이터입니다."),
+
     ;
     private final HttpStatus httpStatus;
     private final String errorMsg;

--- a/src/test/java/com/hhplus/commerce/application/order/OrderCancelIntegrationTest.java
+++ b/src/test/java/com/hhplus/commerce/application/order/OrderCancelIntegrationTest.java
@@ -40,7 +40,7 @@ public class OrderCancelIntegrationTest {
         Item item = createItemAggregateFixture(10L);
         Order order = orderFixture(1L, 2, item.getId());
 
-        orderFacade.orderCancelWithTime(15, order.getCreatedDate().plusMinutes(10));
+        orderFacade.orderCancelWithParam(15, order.getCreatedDate().plusMinutes(10));
 
         Long quantity = itemInventoryRepository.findById(item.getId()).orElseThrow().getQuantity();
         Assertions.assertEquals(quantity, 12L,
@@ -61,7 +61,7 @@ public class OrderCancelIntegrationTest {
         for (int i = 1; i <= threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    orderFacade.orderCancelWithTime(15, order.getCreatedDate().plusMinutes(10));
+                    orderFacade.orderCancelWithParam(15, order.getCreatedDate().plusMinutes(10));
                     success.incrementAndGet();
                 } finally {
                     latch.countDown();

--- a/src/test/java/com/hhplus/commerce/application/payment/IdempotencyCheckServiceTest.java
+++ b/src/test/java/com/hhplus/commerce/application/payment/IdempotencyCheckServiceTest.java
@@ -1,7 +1,6 @@
 package com.hhplus.commerce.application.payment;
 
-import com.hhplus.commerce.support.exception.InvalidParamException;
-import com.hhplus.commerce.config.cleaner.TearDownDatabase;
+import com.hhplus.commerce.config.acceptance.AcceptanceTest;
 import com.hhplus.commerce.domain.customer.Customer;
 import com.hhplus.commerce.domain.payment.Payment;
 import com.hhplus.commerce.domain.payment.PaymentCommand;
@@ -10,6 +9,7 @@ import com.hhplus.commerce.domain.payment.idempotency.PaymentIdempotency;
 import com.hhplus.commerce.infra.customer.CustomerRepository;
 import com.hhplus.commerce.infra.payment.PaymentIdempotencyRepository;
 import com.hhplus.commerce.infra.payment.PaymentRepository;
+import com.hhplus.commerce.support.exception.InvalidParamException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,8 +20,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@TearDownDatabase
-class IdempotencyCheckServiceTest {
+class IdempotencyCheckServiceTest extends AcceptanceTest {
     @Autowired private IdempotencyCheckService idempotencyCheckService;
 
     @Autowired private CustomerRepository customerRepository;

--- a/src/test/java/com/hhplus/commerce/application/payment/PaymentFacadeTest.java
+++ b/src/test/java/com/hhplus/commerce/application/payment/PaymentFacadeTest.java
@@ -3,10 +3,7 @@ package com.hhplus.commerce.application.payment;
 import com.hhplus.commerce.application.order.OrderDataPlatformSendService;
 import com.hhplus.commerce.application.order.dataPlatform.OrderDataPlatformEvent;
 import com.hhplus.commerce.application.order.dataPlatform.OrderDataPlatformPayload;
-import com.hhplus.commerce.support.exception.IllegalStatusException;
-import com.hhplus.commerce.support.exception.InvalidParamException;
-import com.hhplus.commerce.support.response.ErrorCode;
-import com.hhplus.commerce.config.cleaner.TearDownDatabase;
+import com.hhplus.commerce.config.acceptance.AcceptanceTest;
 import com.hhplus.commerce.domain.customer.Customer;
 import com.hhplus.commerce.domain.order.Order;
 import com.hhplus.commerce.domain.order.OrderCommand;
@@ -25,6 +22,9 @@ import com.hhplus.commerce.infra.payment.PaymentHistoryRepository;
 import com.hhplus.commerce.infra.payment.PaymentIdempotencyRepository;
 import com.hhplus.commerce.infra.payment.PaymentRepository;
 import com.hhplus.commerce.infra.point.PointRepository;
+import com.hhplus.commerce.support.exception.IllegalStatusException;
+import com.hhplus.commerce.support.exception.InvalidParamException;
+import com.hhplus.commerce.support.response.ErrorCode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -47,8 +47,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@TearDownDatabase
-public class PaymentFacadeTest {
+//@TearDownDatabase
+public class PaymentFacadeTest extends AcceptanceTest {
     @Autowired private PaymentFacade paymentFacade;
     @Autowired private OrderStore orderStore;
 
@@ -220,7 +220,7 @@ public class PaymentFacadeTest {
 
         OrderDataPlatformPayload orderDataPlatformPayload = OrderDataPlatformPayload.of(OrderDataPlatformEvent.of(order));
         verify(orderDataPlatformSendService, times(1))
-                .send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload.getOrderId()));
+                .send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload));
     }
 
     @Test
@@ -264,7 +264,7 @@ public class PaymentFacadeTest {
 
         OrderDataPlatformPayload orderDataPlatformPayload = OrderDataPlatformPayload.of(OrderDataPlatformEvent.of(order));
         verify(orderDataPlatformSendService, times(0))
-                .send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload.getOrderId()));
+                .send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload));
     }
 
     @Test
@@ -316,7 +316,7 @@ public class PaymentFacadeTest {
 
         OrderDataPlatformPayload orderDataPlatformPayload = OrderDataPlatformPayload.of(OrderDataPlatformEvent.of(order));
         verify(orderDataPlatformSendService, times(2))
-                .send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload.getOrderId()));
+                .send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload));
     }
 
     //paymentIdempotency

--- a/src/test/java/com/hhplus/commerce/config/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/hhplus/commerce/config/acceptance/AcceptanceTest.java
@@ -39,7 +39,7 @@ public class AcceptanceTest {
 
     @AfterEach
     void tearDown() {
-        databaseCleanListener.clearH2();
+        databaseCleanListener.clearMySQL();
     }
 }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    default: local
+    default: prod


### PR DESCRIPTION
### Todo-list
- 데이터 플랫폼 전송 Kafka
  - [x] Kafka Listener 생성
  - [x] Kafka Publish 및 Consumer 구현
- 데이터 플랫폼 전송 아웃박스 트랜잭셔널
  - [x] 아웃박스 트랜잭셔널 Listener 생성
  - [x] 아웃박스 트랜잭셔널 save 구현 
  - [x] 배치를 통해 `processed=false` 데이터 플랫폼 전송 및 `true`처리

## 이번 과제 목표
- 기존에 데이터 플랫폼 전송을 `@TransactionalEventListener` 대신 Transactional Outbox Pattern을 적용한다.

## 구현 방향
### 1. 기존 코드는 최대한 유지
1-1. 기존 결제 프로세스의 이벤트 발행 코드는 유지
```java
// 데이터 플랫폼 전송 이벤트 -> 트랜잭셔널 아웃박스 패턴 
orderDataPlatformPublisher.success(OrderDataPlatformEvent.of(order));
```

1-2. 기존에 이벤트 방식 Listener는 삭제하지 않고 주석처리하여 동작하지 않도록 함(추후 재사용을 고려)
```java
  //@Async
  //@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
  public void orderDataPlatformHandler(OrderDataPlatformEvent event) {
      OrderDataPlatformPayload orderDataPlatformPayload = OrderDataPlatformPayload.of(event);
      orderDataPlatformManageService.send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload));
  }
```

### 2. Listener를 Kafka와 Outbox로 갈아끼우도록 작업
2-1.  아웃박스에 이벤트 데이터 저장(`BEFORE_COMMIT`으로 카프카 메세지 발행 전에 실행되도록 설정) [OrderDataPlatformRecordListener.java](https://github.com/sunggyupaik/hhplus-commerce-java-3/blob/step18/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformRecordListener.java)

- `processed=false` 상태로 `Outbox` 데이터  저장
```java
public void create(OutBoxCommand.SaveRequest request) {
  eventStore.save(request.toEntity());
}
```

2-2. 카프카에 메세지 발행(`AFTER_COMMIT`으로 모든 작업이 커밋 된 이후 동작하도록 설정)  [OrderDataPlatformMessageListener.java](https://github.com/sunggyupaik/hhplus-commerce-java-3/blob/step18/src/main/java/com/hhplus/commerce/application/order/dataPlatform/OrderDataPlatformMessageListener.java)

- 카프카에 메세지 발행하고 Listener를 통해 데이터플랫폼 전송 및 `processed=true` 로 업데이트
```java
//데이터 플랫폼 전송
orderDataPlatformManageService.send(OrderCommand.OrderDataPlatformRequest.of(orderDataPlatformPayload));

//아웃박스 테이블 `processed = true`로 변경
Outbox outbox = orderExternalEventService.findOutbox(command);
orderExternalEventService.changeToProcessedTrue(outbox);
```

### 3. 배치를 돌며 10분 이상 지난 `processed=false`인 `Outbox` 재실행
```java
@Transactional
public void orderExternalEventOrderDataPlatformSendBatch() {
    OutBoxCommand.FindAllRequest request = OutBoxCommand.FindAllRequest.of(
            OrderDataPlatformEvent.ORDER_DATA_PLATFORM_EVENT_V1_TOPIC, false
    );
   // 데이터 플랫폼 전송 실패 건들 모두 조회
    List<Outbox> outboxes = orderExternalEventService.findAll(request);

    outboxes.forEach(outbox -> {
        if (outbox.getCreatedDate().plusMinutes(PROCESSED_CHECK_MINUTE).isAfter(LocalDateTime.now())) {
            orderDataPlatformManageService.send(OrderCommand.OrderDataPlatformRequest.of(outbox.getMessage()));
            orderExternalEventService.changeToProcessedTrue(outbox);
        }
    });
}
```
